### PR TITLE
Add hwr-production-dot-remarkable-production.appspot.com to README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Install a root CA on the device, you can use the `device/gencert.sh` script
             - stop xochitl `systemctl stop xochitl`
             - add to /etc/hosts
                 ```
+		127.0.0.1 hwr-production-dot-remarkable-production.appspot.com
                 127.0.0.1 service-manager-production-dot-remarkable-production.appspot.com
                 127.0.0.1 local.appspot.com
                 127.0.0.1 my.remarkable.com


### PR DESCRIPTION
This host is required to resolve to rmfakecloud server as well.