### PR TITLE
app: Use base64 RawURLEncoding to decode the JWT token

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -72,7 +72,7 @@ func getToken(c *gin.Context) (string, error) {
 		return "", nil
 	}
 
-	payload, err := base64.StdEncoding.DecodeString(parts[1])
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
 	if err != nil {
 		log.Warnln("decode token err", err)
 		return string(payload), nil


### PR DESCRIPTION
JWT tokens use URLEncoding, which is an url-safe version of standard
base64 (no padding, + and / characters replaced). Go implements
no-padding version as RawURLEncoding.

Supercedes #13.