### PR TITLE
Various SMTP-related fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ In order to get hwr running with myScript register for a developer account and s
 # Sending emails
 Define the following env variables (only gmail has been tested):
 
-`RM_SMTP_SERVER` e.g. smtp.gmail.com:465  
-`RM_STMP_USERNAME`  
-`RM_STMP_PASSWORD` (colud try with app password)  
+`RM_SMTP_SERVER` e.g. smtp.gmail.com:465
+`RM_SMTP_USERNAME`
+`RM_SMTP_PASSWORD` (colud try with app password)
+`RM_SMTP_FROM` (i.e. "ReMarkable self-hosted <remarkable@mydomain.com>")
 
 # Prerequisites / Device Modifications
 

--- a/README.md
+++ b/README.md
@@ -36,12 +36,18 @@ In order to get hwr running with myScript register for a developer account and s
 `RMAPI_HWR_HMAC`
 
 # Sending emails
-Define the following env variables (only gmail has been tested):
+Define the following env variables:
 
-`RM_SMTP_SERVER` e.g. smtp.gmail.com:465
-`RM_SMTP_USERNAME`
-`RM_SMTP_PASSWORD` (colud try with app password)
-`RM_SMTP_FROM` (i.e. "ReMarkable self-hosted <remarkable@mydomain.com>")
+```
+RM_SMTP_SERVER=smtp.gmail.com:465
+RM_SMTP_USERNAME=user@domain.com
+RM_SMTP_PASSWORD=plaintextpass  # Application password should work
+```
+
+If you want to provide custom FROM header for your mails, you can use:
+```
+RM_SMTP_FROM='"ReMarkable self-hosted" <user@domain.com>'
+```
 
 # Prerequisites / Device Modifications
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Install a root CA on the device, you can use the `device/gencert.sh` script
             - stop xochitl `systemctl stop xochitl`
             - add to /etc/hosts
                 ```
-		127.0.0.1 hwr-production-dot-remarkable-production.appspot.com
+                127.0.0.1 hwr-production-dot-remarkable-production.appspot.com
                 127.0.0.1 service-manager-production-dot-remarkable-production.appspot.com
                 127.0.0.1 local.appspot.com
                 127.0.0.1 my.remarkable.com

--- a/internal/email/smtp.go
+++ b/internal/email/smtp.go
@@ -24,7 +24,7 @@ func init() {
 	if servername == "" {
 		log.Warnln("smtp not configured, no emails will be sent")
 	}
-	fromOverride = os.Getenv("RM_STMTP_FROM")
+	fromOverride = os.Getenv("RM_SMTP_FROM")
 }
 
 type EmailBuilder struct {

--- a/internal/email/smtp.go
+++ b/internal/email/smtp.go
@@ -119,7 +119,7 @@ func (b *EmailBuilder) Send() (err error) {
 	}
 	delimeter := "**=myohmy689407924327898338383"
 	//basic email headers
-	msg := fmt.Sprintf("From: %s\r\n", b.From)
+	msg := fmt.Sprintf("From: %s\r\n", from)
 	msg += fmt.Sprintf("To: %s\r\n", b.To)
 	msg += fmt.Sprintf("Subject: %s\r\n", b.Subject)
 	// msg += fmt.Sprintf("ReplyTo: %s\r\n", b.ReplyTo)

--- a/internal/email/smtp.go
+++ b/internal/email/smtp.go
@@ -160,6 +160,14 @@ func (b *EmailBuilder) Send() (err error) {
 			return err
 		}
 	}
+
+	// Add last boundary delimeter, with trailing -- according to RFC 1341
+	last_boundary := fmt.Sprintf("\r\n--%s--\r\n", delimeter)
+	_, err = w.Write([]byte(last_boundary))
+	if err != nil {
+		return err
+	}
+
 	err = w.Close()
 	if err != nil {
 		return err


### PR DESCRIPTION
This MR implements following fixes:
* makes sure that `RM_SMTP_FROM` is correctly read from the environment and respected in the email message headers
* ensures the last boundary delimeter is added (closes #15)
* minor improvements and typo fixes in the SMTP-related part of README.md