### PR TITLE
storage: Fix path to trash directory

### DIFF
--- a/internal/storage/fs/storage.go
+++ b/internal/storage/fs/storage.go
@@ -52,13 +52,13 @@ func (fs *Storage) RemoveDocument(id string) error {
 	trashDir := fs.Cfg.TrashDir
 	meta := fmt.Sprintf("%s.metadata", id)
 	fullPath := path.Join(dataDir, meta)
-	err := os.Rename(fullPath, path.Join(dataDir, trashDir, meta))
+	err := os.Rename(fullPath, path.Join(trashDir, meta))
 	if err != nil {
 		return err
 	}
 	meta = fmt.Sprintf("%s.zip", id)
 	fullPath = path.Join(dataDir, meta)
-	err = os.Rename(fullPath, path.Join(dataDir, trashDir, meta))
+	err = os.Rename(fullPath, path.Join(trashDir, meta))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The trashDir is defined as subdirectory of dataDir, joining it with
dataDir again leads to dataDir being included twice.

This leads to the deletion operation erroring out with:

```
time="2020-11-02T04:12:33Z" level=error
msg="rename /data/2022e89d-eeb4-4a1d-84d1-efb9f3d4f8cb.metadata /data/data/trash/2022e89d-eeb4-4a1d-84d1-efb9f3d4f8cb.metadata: no such file or directory"
```

