### PR TITLE
Ensure Document list is created to avoid nil slice

### DIFF
--- a/internal/storage/fs/metadata.go
+++ b/internal/storage/fs/metadata.go
@@ -18,6 +18,8 @@ func (fs *Storage) GetAllMetadata(uid string, withBlob bool) (result []*messages
 	folder := path.Join(fs.Cfg.DataDir, userDir, uid)
 	files, err := ioutil.ReadDir(folder)
 
+	result = []*messages.RawDocument{}
+
 	for _, f := range files {
 		ext := filepath.Ext(f.Name())
 		id := strings.TrimSuffix(f.Name(), ext)


### PR DESCRIPTION
https://discord.com/channels/385916768696139794/386181213699702786/810942538373398528

The line has been remove in https://github.com/ddvk/rmfakecloud/commit/04487cbf21aeac878be632c2b018d203fc927a81, giving a `null` instead of `[]`. `null` prevents reMarkable to do the initial sync.