### PR TITLE
Improve suggested nginx config

### DIFF
--- a/docs/https.md
+++ b/docs/https.md
@@ -32,7 +32,7 @@ INFO[0387] [GIN] 2020/11/17 - 13:39:41 | 400 |      201.78µs |       127.0.0.1 
 
 So, I tried with an nginx reverse proxy with the following config:
 
-```
+```nginx
 server {
     # increase max request size (for large PDFs)
     client_max_body_size 200M;
@@ -53,16 +53,12 @@ server {
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
+
+      proxy_read_timeout 1d;
+      proxy_send_timeout 1d;
     }
   }
-
-  upstream ws-backend {
-    # enable sticky session based on IP
-    ip_hash;
-
-    server localhost:3000;
 }
-
 ```
 
 That seems to work well.


### PR DESCRIPTION
This PR contains some improvements for the suggested nginx reverse proxy configuration:

* Remove the unused `upstream {}` block
* Set the connection timeout to 1 day instead of the default 60 seconds, otherwise WebSockets connections get closed automatically after 60 seconds.

I have confirmed these changes to work on my rmfakecloud instance. Without the increased timeout, the WebSocket connection gets closed every 60 s with an error message in the server logs and Xochitl reestablishes a new connection.

See also: <https://nginx.org/en/docs/http/websocket.html>