### PR TITLE
Append origin server to display account name

### DIFF
--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -136,7 +136,7 @@ func (app *App) newUserToken(c *gin.Context) {
 			Connection:    "Username-Password-Authentication",
 			Name:          user.Email,
 			Nickname:      user.Email, // user.Nickname,
-			Email:         user.Email,
+			Email:         fmt.Sprintf("%s (via %s)", user.Email, app.cfg.StorageURL),
 			EmailVerified: true,
 			Picture:       "image.png",
 			CreatedAt:     time.Now(),


### PR DESCRIPTION
This PR appends the name of the origin server (taken from the StorageURL configuration item) to all display account names. This shows up in Xochitl’s general settings panel. This is useful to know at a glance whether you’re connected to the official servers or an rmfakecloud server, and if so, to which rmfakecloud server.

Tested on my personal rmfakecloud instance with a connected rM2 running system version 2.10.1.332 (email and server name redacted):

![rmfakecloud-username-origin](https://user-images.githubusercontent.com/1370040/137753275-da547bc4-6277-449d-a52d-64b9bf33b221.png)
