### PR TITLE
Add instructions for non x64 binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,16 @@ Install and build the project, under Linux:
 `git clone https://github.com/ddvk/rmfakecloud`  
 `make`
 
+`make` will just build the x64 binary. If you need binaries for other architectures, you should instead run `make all`.
+
 run  
 `~/dist/rmfakecloud-x64`
 
 or clone an do: `go run .`  
 or `make run`  
-or `make` artifacts are in the `dist` folder. the Arm binaries work on pi3 / Synology etc  
-or `make docker && ./rundocker.sh`  
+or `make all` artifacts are in the `dist` folder. the Arm binaries work on pi3 / Synology etc  
+or `make docker && ./rundocker.sh`
+
 
 ### Docker
 `docker run -it --rm -p 3000:3000 -e JWT_SECRET_KEY='something' ddvk/rmfakecloud` (you can pass `-h` to see the available options


### PR DESCRIPTION
`make` now only builds `x64` binaries by default. Adding instructions to use `make all` if you need other binaries.