### PR TITLE
Ensure JWT algorithm is the one expected during validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.0.3 // indirect
 	github.com/gin-gonic/gin v1.7.4
 	github.com/go-playground/validator/v10 v10.9.0 // indirect
-	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/golang-jwt/jwt/v4 v4.2.0
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v4 v4.2.0 h1:besgBTC8w8HjP6NzQdxwKH9Z5oQMZ24ThTrHp3cZ8eU=
+github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/internal/app/claims.go
+++ b/internal/app/claims.go
@@ -3,7 +3,7 @@ package app
 import (
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 // DeviceClaims device

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -18,7 +18,7 @@ import (
 	"github.com/ddvk/rmfakecloud/internal/messages"
 	"github.com/ddvk/rmfakecloud/internal/storage/models"
 	"github.com/gin-gonic/gin"
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/gorilla/websocket"
 	log "github.com/sirupsen/logrus"
 )

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -6,8 +6,10 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 )
+
+var signingMethod = jwt.SigningMethodHS256
 
 // GetToken gets the token from the headers
 func GetToken(c *gin.Context) (string, error) {
@@ -30,14 +32,14 @@ func ClaimsFromToken(claim jwt.Claims, token string, key []byte) error {
 	_, err := jwt.ParseWithClaims(token, claim,
 		func(token *jwt.Token) (interface{}, error) {
 			return key, nil
-		})
+		}, jwt.WithValidMethods([]string{signingMethod.Name}))
 
 	return err
 }
 
 // SignClaims signs the claims i.e. creates a token
 func SignClaims(claims jwt.Claims, key []byte) (string, error) {
-	jwtToken := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	jwtToken := jwt.NewWithClaims(signingMethod, claims)
 	jwtToken.Header["kid"] = "1"
 	return jwtToken.SignedString(key)
 }

--- a/internal/storage/fs/claims.go
+++ b/internal/storage/fs/claims.go
@@ -1,6 +1,6 @@
 package fs
 
-import "github.com/golang-jwt/jwt"
+import "github.com/golang-jwt/jwt/v4"
 
 // StorageClaim used for file retrieval
 type StorageClaim struct {

--- a/internal/storage/fs/documents.go
+++ b/internal/storage/fs/documents.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/ddvk/rmfakecloud/internal/common"

--- a/internal/ui/claims.go
+++ b/internal/ui/claims.go
@@ -1,6 +1,6 @@
 package ui
 
-import "github.com/golang-jwt/jwt"
+import "github.com/golang-jwt/jwt/v4"
 
 // WebUserClaims the claims
 type WebUserClaims struct {

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ddvk/rmfakecloud/internal/model"
 	"github.com/ddvk/rmfakecloud/internal/ui/viewmodel"
 	"github.com/gin-gonic/gin"
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 )


### PR DESCRIPTION
Hi,

This commit update go-jwt dependency and validate the `alg` in the claim, as requested by the [second security notice](https://github.com/golang-jwt/jwt#jwt-go).

Now, if a bad alg is presented, the auth middleware fails with:

```
WARN[0024] [ui-authmiddleware] token verification, signing method HS512 is invalid
```