### PR TITLE
docs: how-to reenable tablet proxy after upgrades

### DIFF
--- a/docs/remarkable/setup.md
+++ b/docs/remarkable/setup.md
@@ -2,6 +2,10 @@
 
 There are several ways to make it work, choose whatever works for you
 
+**IMPORTANT**: whenever the tablet receives a system update, the cloud
+connection will break, and [will have to be
+reenabled](#reenabling-after-a-system-update).
+
 ## Automatic
 
 ### toltec
@@ -85,3 +89,28 @@ Same as [the previous method](#modify-/etc/hosts), but instead of modifying any 
 
 **PROS**: a bit easier, you can you even the mobile apps if you manage to install the root ca  
 **CONS**: you can't use the official cloud anymore due to the mangled DNS
+
+## Reenabling after a system update
+
+Navigate to whatever directory the proxy was downloaded to on your device.
+
+* If you installed using the rmfakecloud-proxy script, this will likely be
+  `~/rmfakecloud/`.
+
+Run the below commands to reinstall the proxy service, which should reenable
+your cloud connection.
+
+```
+# stop services
+systemctl stop xochitl
+systemctl stop proxy
+
+# reinstall the proxy service
+./installer.sh uninstall
+./installer.sh install
+
+# restart services
+systemctl daemon-reload
+systemctl start proxy
+systemctl start xochitl
+```


### PR DESCRIPTION
After the tablet receives a system update, the tablet deletes the `proxy` systemd service that is needed for the tablet to reach the user's cloud. The user needs to reinstall the service after an upgrade. This PR adds easy steps to the docs on how to do this.

I could do with some feedback on whether this is the best approach for other installation methods, like the [toltec](https://ddvk.github.io/rmfakecloud/remarkable/setup/#toltec) package.

Also, does anyone know for sure whether the user needs to disconnect from their cloud after these steps? I'll add that info too if needed.

***

As I noted in [#101](https://github.com/ddvk/rmfakecloud/issues/101#issuecomment-970440866_), and as previously mentioned in #90, the user can reinstall the service to get the tablet connection working again with the below:

```
# stop services
systemctl stop xochitl
systemctl stop proxy

# reinstall the proxy service
./installer.sh uninstall
./installer.sh install

# restart services
systemctl daemon-reload
systemctl start proxy
systemctl start xochitl
```

At least, that's the steps that I used, having originally installed the proxy using the [`rmfakecloud-proxy` script](https://ddvk.github.io/rmfakecloud/remarkable/setup/#rmfakecloud-proxy-script).