### PR TITLE
make DefaultHost configurable as STORAGE_HOST

### DIFF
--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/ddvk/rmfakecloud/internal/app/hub"
 	"github.com/ddvk/rmfakecloud/internal/common"
-	"github.com/ddvk/rmfakecloud/internal/config"
 	"github.com/ddvk/rmfakecloud/internal/email"
 	"github.com/ddvk/rmfakecloud/internal/hwr"
 	"github.com/ddvk/rmfakecloud/internal/integrations"
@@ -519,9 +518,9 @@ func (app *App) updateStatus(c *gin.Context) {
 func (app *App) locateService(c *gin.Context) {
 	svc := c.Param("service")
 	log.Infof("Requested: %s\n", svc)
-	host := config.DefaultHost
+	host := app.cfg.StorageHost
 	if svc == "blob-storage" {
-		host = "https://" + config.DefaultHost
+		host = app.cfg.StorageURL
 	}
 	response := messages.HostResponse{Host: host, Status: "OK"}
 	c.JSON(http.StatusOK, response)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,8 @@ const (
 	envPort    = "PORT"
 	// EnvStorageURL the external name of the service
 	EnvStorageURL = "STORAGE_URL"
+	// EnvStorageHOST the external name of the service
+	EnvStorageHost = "STORAGE_HOST"
 	// envTLSCert the path of the cert file
 	envTLSCert = "TLS_CERT"
 	// envTLSKey the path of the private key
@@ -78,6 +80,7 @@ const (
 type Config struct {
 	Port              string
 	StorageURL        string
+	StorageHost       string
 	DataDir           string
 	RegistrationOpen  bool
 	CreateFirstUser   bool
@@ -160,10 +163,14 @@ func FromEnv() *Config {
 	openRegistration, _ := strconv.ParseBool(os.Getenv(envRegistrationOpen))
 	httpsCookie, _ := strconv.ParseBool(os.Getenv(envHTTPSCookie))
 
+	storageHost := os.Getenv(EnvStorageHost)
+	if storageHost == "" {
+		storageHost = DefaultHost
+	}
 	uploadURL := os.Getenv(EnvStorageURL)
 	if uploadURL == "" {
 		//it will go through the local proxy
-		uploadURL = "https://" + DefaultHost
+		uploadURL = "https://" + storageHost
 	}
 
 	// smtp
@@ -199,6 +206,7 @@ func FromEnv() *Config {
 	cfg := Config{
 		Port:              port,
 		StorageURL:        uploadURL,
+		StorageHost:       storageHost,
 		DataDir:           dataDir,
 		JWTSecretKey:      dk,
 		JWTRandom:         jwtGenerated,


### PR DESCRIPTION
this changes the reply from handlers.go/locateService, so that the
cloud is usable by custom clients without modification to /etc/hosts.

we got rmfuse working with a small patch in rmcl