### PR TITLE
Improve installation docs on the matter of URLs

### DIFF
--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -1,18 +1,16 @@
 The configuration is made through environment variables.
 
-
 ## General configuration
 
 | Variable name     | Description |
 |-------------------|-------------|
-| `JWT_SECRET_KEY`  | The secret key used to sign the authentication token<br>If you don't provide it, a random secret is generated, invalidating all connections established previously to be closed.<br>A good secret is for example: `openssl rand -base64 48` |
-| `STORAGE_URL`     | It controls whether file upload/download goes through the local proxy or to an external server. It's the address of rmfakecloud **as visible from the tablet**, especially if the host is behind a reverse proxy or in a container (default: `https://local.appspot.com`) |
+| `JWT_SECRET_KEY`  | The secret key used to sign the authentication token.<br>If you don't provide it, a random secret is generated, invalidating all connections established previously to be closed.<br>A good secret is for example: `openssl rand -base64 48` |
+| `STORAGE_URL`     | It controls whether file upload/download goes through the local proxy or to an external server. It's the full address (protocol, host, port, path) of rmfakecloud **as visible from the tablet**, especially if the host is behind a reverse proxy or in a container. Example: `http://192.168.2.3:3000` (default: `https://local.appspot.com`) |
 | `PORT`            | listening port number (default: 3000) |
 | `DATADIR`         | Set data/files directory (default: `data/` in current dir) |
 | `LOGLEVEL`        | Set the log verbosity. Default is **info**, set to **debug** for more logging or **warn**, **error** for less |
 | `RM_HTTPS_COOKIE` | For the UI, force cookies to be available only via https |
 | `RM_TRUST_PROXY`  | Trust the proxy for client ip addresses (X-Forwarded-For/X-Real-IP) default false |
-
 
 ## Handwriting recognition
 
@@ -24,7 +22,6 @@ Then you'll obtains an application key and its corresponding HMAC to give to rmf
 |----------------------------|-------------|
 | `RMAPI_HWR_APPLICATIONKEY` | Application key obtained from myscript |
 | `RMAPI_HWR_HMAC`           | HMAC obtained from myscript |
-
 
 ## Email settings
 

--- a/docs/install/source.md
+++ b/docs/install/source.md
@@ -33,13 +33,14 @@ Installing
 5. Enable and start the service with your init system.
    e.g. `rc-update add rmfakecloud && service start rmfakecloud` or `systemctl enable --now rmfakecloud`
 
-
 Init System Examples
 ====================
 
 OpenRC
 ------
+
 /etc/init.d/rmfakecloud
+
 ```sh
 #!/sbin/openrc-run
 
@@ -56,6 +57,7 @@ depend() {
 ```
 
 /etc/conf.d/rmfakecloud
+
 ```sh
 # Basic settings
 export JWT_SECRET_KEY=SOME_KEY
@@ -82,7 +84,9 @@ Make sure to replace `SOME_KEY` by the return of `openssl rand -base64 48`, see 
 
 systemd
 -------
+
 rmfakecloud.service
+
 ```ini
 [Unit]
 Description=rmfakecloud
@@ -99,6 +103,7 @@ WantedBy=multi-user.target
 ```
 
 rmfakecloud.conf
+
 ```sh
 JWT_SECRET_KEY=SOME_KEY
 STORAGE_URL=http(s)://host.where.rmfakecloud.is.running

--- a/docs/remarkable/setup.md
+++ b/docs/remarkable/setup.md
@@ -10,26 +10,35 @@ There are several ways to make it work, choose whatever works for you
 ## Automatic
 
 ### toltec
+
 Install using [toltec](https://toltec-dev.org/).
+
 ```commandline
 opkg install rmfakecloud-proxy
 rmfakecloudctl set-upstream <URL>
 rmfakecloudctl enable
 ```
 
+The `<URL>` above has to be the same as in the `STORAGE_URL` server configuration.
+
 ### rmfakecloud-proxy script
+
 Get the installer from: [rmfakecloud-proxy](https://github.com/ddvk/rmfakecloud-proxy/releases)
 or run the automagic:
+
 ```commandline
 sh -c "$(wget https://raw.githubusercontent.com/ddvk/rmfakecloud/master/scripts/device/automagic.sh -O-)"
 ```
 
 ## Manual
+
 ### Installing a proxy on devices
+
 A reverse proxy [rmfakecloud-proxy](https://github.com/ddvk/rmfakecloud-proxy/releases) has to be installed
 run rmfakecloud on whichever port you want, you can use either HTTP (not recommended) or HTTPS, generate a new cert for the url you chose e.g with Let's Encrypt
 
 Steps (done by the automagic scripts):
+
 - generate a CA and host certificate for `*.appspot.com`
 - create the CA folder: `mkdir -p /usr/local/share/ca-certificates`
 - copy the CA.crt file to `/usr/local/share/ca-certificates` and run `update-ca-certificates`
@@ -37,14 +46,16 @@ Steps (done by the automagic scripts):
 - Run a reverse https proxy on the rm tablet as a service, e.g. [secure](https://github.com/yi-jiayu/secure),
 - stop xochitl `systemctl stop xochitl`
 - add the followint entries to `/etc/hosts`
-```
+
+    ```
     127.0.0.1 hwr-production-dot-remarkable-production.appspot.com
     127.0.0.1 service-manager-production-dot-remarkable-production.appspot.com
     127.0.0.1 local.appspot.com
     127.0.0.1 my.remarkable.com
     127.0.0.1 ping.remarkable.com
     127.0.0.1 internal.cloud.remarkable.com
-```
+    ```
+
 - set the address of your api host:port in the reverse proxy
     `secure -cert proxy.crt -key proxy.key http(s)://host_where_the_api_is_running:someport`
     or use the provided systemd unit file and put the config in proxycfg
@@ -54,6 +65,7 @@ Steps (done by the automagic scripts):
 - start xochitl `systemctl start xochitl`
 
 Windows/Mac Desktop Client:
+
 - modify the hosts file (`\system32\drivers\etc\hosts`) add the same entries as on the tablet
 - run a reverse proxy on the host or somewhere else pointing it to rmfakecloud with the same certs
 - profit
@@ -62,19 +74,24 @@ Windows/Mac Desktop Client:
 **CONS**: you have to configure HTTPS on the host yourself, additional Desktop config
 
 ### Modify device /etc/hosts
+
 Connect to the host directly, without a reverse proxy, with HTTPS on :443
 
 Steps:
+
 - generate the certs from Variant 1, you get them (proxy.crt, proxy.key, ca.crt) and trust the ca.crt
 - run rmfakecloud with:
-```
+
+    ```
     TLS_KEY=proxy.key
     TLS_CERT=proxy.crt
     STORAGE_URL=https://local.apphost.com
-```
+    ```
+
 - modify `/etc/hosts` but use the rmfakecloud's ip instead of 127.0.0.1
 
 Windows/Mac Desktop Client:
+
 - trust the `ca.crt`  (add it to Trusted Root CA, use cert.msc)
 - modify the hosts file (`\system32\drivers\etc\hosts`) add the same entries as on the tablet
 - profit
@@ -83,7 +100,9 @@ Windows/Mac Desktop Client:
 **CONS**: a bit harder to setup, each host has to trust the ca and modify the hosts file, you have to use port 443
 
 ### Edit router DNS entries
+
 Same as [the previous method](#modify-/etc/hosts), but instead of modifying any hosts file, make the changes on your DNS/router:
+
 - add the host entries directly on your router (Hosts in OpenWRT)
 - trust the ca.crt
 - profit
@@ -95,7 +114,7 @@ Same as [the previous method](#modify-/etc/hosts), but instead of modifying any 
 
 Navigate to whatever directory the proxy was downloaded to on your device.
 
-* If you installed using the rmfakecloud-proxy script, this will likely be
+- If you installed using the rmfakecloud-proxy script, this will likely be
   `~/rmfakecloud/`.
 
 Run the below commands to reinstall the proxy service, which should reenable
@@ -119,8 +138,12 @@ systemctl start xochitl
 # Login
 
 After you installed the proxy, you will need to login to your account on your device.
-1. Click `Menu > General > Account`
-2. Click on `Setup Account`
-3. On you main computer: Login to https://rmfakecloud.server.net then go to https://rmfakecloud.server.net/generatecode
-4. Enter the shown code on your device
-5. To check that sync is working correctly. Go to `Menu > Storage` and press 
+
+1. Click `Menu > General > Account`.
+2. Click on `Setup Account`.
+3. On your main computer:
+    1. Login to the rmfakecloud Web UI (if no proxy used, the same as the `STORAGE_URL` value in the server configuration).
+    2. Press the `Code` link in the menu.
+    3. Press the `Generate Code` button.
+4. Enter the shown code on your device.
+5. To check that sync is working correctly. Go to `Menu > Storage` and press `Check Sync`.


### PR DESCRIPTION
1. Describe a little bit better which URLs where should be used. It's not perfect but the best I can do without changing too much.
2. Add a few empty lines in docs as advised by markdownlint.

Closes #165 