### PR TITLE
STARTTLS settings clarification

### DIFF
--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -34,6 +34,6 @@ To be able to send email from your reMarkable, fill the following variables:
 | `RM_SMTP_PASSWORD`     | Plaintext password (application password should work) |
 | `RM_SMTP_FROM`         | Custom `From:` header for the mails (eg. 'ReMarkable self-hosted <remarkable@my.example.net>') |
 | `RM_SMTP_HELO`         | Custom HELO, if your email provider needs it |
-| `RM_SMTP_NOTLS=1` | don't use tls |
-| `RM_SMTP_STARTTLS=1` | use starttls command (in most cases port 587 should be used), should be combined with NOTLS |
-| `RM_SMTP_INSECURE_TLS=1` | If set, don't check the server certificate (not recommended) |
+| `RM_SMTP_NOTLS` | don't use tls |
+| `RM_SMTP_STARTTLS` | use starttls command, should be combined with NOTLS. in most cases port 587 should be used |
+| `RM_SMTP_INSECURE_TLS` | If set, don't check the server certificate (not recommended) |

--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -25,10 +25,6 @@ Then you'll obtains an application key and its corresponding HMAC to give to rmf
 
 ## Email settings
 
-!!! warning
-    STARTTLS has not been tested
-    Port 465 is most likely the one to use instead of 587, if your provider supports it.
-
 To be able to send email from your reMarkable, fill the following variables:
 
 | Variable name          | Description |
@@ -38,6 +34,6 @@ To be able to send email from your reMarkable, fill the following variables:
 | `RM_SMTP_PASSWORD`     | Plaintext password (application password should work) |
 | `RM_SMTP_FROM`         | Custom `From:` header for the mails (eg. 'ReMarkable self-hosted <remarkable@my.example.net>') |
 | `RM_SMTP_HELO`         | Custom HELO, if your email provider needs it |
-| `RM_SMTP_NOTLS` | don't use tls |
-| `RM_SMTP_STARTTLS` | use starttls command, should be combined with NOTLS |
-| `RM_SMTP_INSECURE_TLS` | If set, don't check the server certificate (not recommended) |
+| `RM_SMTP_NOTLS=1` | don't use tls |
+| `RM_SMTP_STARTTLS=1` | use starttls command (in most cases port 587 should be used), should be combined with NOTLS |
+| `RM_SMTP_INSECURE_TLS=1` | If set, don't check the server certificate (not recommended) |


### PR DESCRIPTION
Hello everyone,

I tested the smtp configuration using both my own mail server and gmail. It turned out that the remarkable is only able to send emails when STARTTLS is used on port 587 not on 465. I also tried to clarify that 0 or 1 should be used when enabling/disabling an environment variable.  