### PR TITLE
SizeInBytes field is a string

### DIFF
--- a/internal/storage/models/hashdoc.go
+++ b/internal/storage/models/hashdoc.go
@@ -164,7 +164,13 @@ func (d *HashDoc) readContent(hash string, r RemoteStorage) error {
 		log.Printf("cannot read content %s %v", hash, err)
 	}
 	d.PayloadType = contentFile.FileType
-	d.Size = int64(contentFile.SizeInBytes)
+
+	if len(contentFile.SizeInBytes) > 0 {
+		d.Size, err = strconv.ParseInt(contentFile.SizeInBytes, 10, 64)
+		if err != nil {
+			log.Printf("invalid SizeInBytes: %s %s %v", contentFile.SizeInBytes, hash, err)
+		}
+	}
 
 	return nil
 }

--- a/internal/storage/models/metadatafile.go
+++ b/internal/storage/models/metadatafile.go
@@ -57,7 +57,7 @@ type ContentFile struct {
 	Pages          []interface{} `json:"pages"`
 	TextScale      int           `json:"textScale"`
 	Transform      Transform     `json:"transform"`
-	SizeInBytes    int64         `json:"sizeInBytes"`
+	SizeInBytes    string        `json:"sizeInBytes"`
 }
 type ExtraMetadata struct {
 	LastPen             string `json:"LastPen"`


### PR DESCRIPTION
This commit fixes the error reported when building a doctree:

```
INFO[0002] cannot read content 316c32af4484a2639bc4c9ec222b276df346bee6eab310afea501cb1d905fa0d json: cannot unmarshal string into Go struct field ContentFile.sizeInBytes of type int64
```

It appears that in all my accessible history `SizeInBytes` are only strings.

```
$ grep sizeInBytes users/myuser/sync/*
    "sizeInBytes": "25653932",
    "sizeInBytes": "69847",
    "sizeInBytes": "58852",
    "sizeInBytes": "777960",
    "sizeInBytes": "4432845",
    "sizeInBytes": "7562644",
    "sizeInBytes": "20679149",
    "sizeInBytes": "24947",
    "sizeInBytes": "1186636",
    "sizeInBytes": "49559398",
    "sizeInBytes": "2357853",
    "sizeInBytes": "67346",
    "sizeInBytes": "22355266",
    "sizeInBytes": "36074730",
    "sizeInBytes": "878434",
    "sizeInBytes": "25670734",
    "sizeInBytes": "2078260",
    "sizeInBytes": "465644",
    "sizeInBytes": "193641",
    "sizeInBytes": "23797844",
    "sizeInBytes": "23117121",
    "sizeInBytes": "35828241",
    "sizeInBytes": "54193876",
    "sizeInBytes": "339471",
    "sizeInBytes": "1124795",
    "sizeInBytes": "1175124",
    "sizeInBytes": "283940",
    "sizeInBytes": "1579075",
    "sizeInBytes": "213491",
    "sizeInBytes": "308653",
    "sizeInBytes": "73358",
    "sizeInBytes": "27846",
[...]
```