### PR TITLE
ui: Add interface to manage integrations

### DIFF
--- a/internal/integrations/integrations.go
+++ b/internal/integrations/integrations.go
@@ -37,12 +37,12 @@ func GetIntegrationProvider(storer storage.UserStorer, uid, integrationid string
 			continue
 		}
 		switch intg.Provider {
-		case webdavProvider:
-			return newWebDav(intg), nil
 		case dropboxProvider:
 			return newDropbox(intg), nil
 		case localfsProvider:
 			return newLocalFS(intg), nil
+		case webdavProvider:
+			return newWebDav(intg), nil
 		}
 	}
 	return nil, fmt.Errorf("integration not found or no implmentation (only webdav) %s", integrationid)

--- a/internal/ui/routes.go
+++ b/internal/ui/routes.go
@@ -72,6 +72,13 @@ func (app *ReactAppWrapper) RegisterRoutes(router *gin.Engine) {
 	auth.POST("folders", app.createFolder)
 	auth.GET("documents/:docid/metadata", app.getDocumentMetadata)
 
+	// integrations
+	auth.GET("integrations", app.listIntegrations)
+	auth.POST("integrations", app.createIntegration)
+	auth.GET("integrations/:intid", app.getIntegration)
+	auth.PUT("integrations/:intid", app.updateIntegration)
+	auth.DELETE("integrations/:intid", app.deleteIntegration)
+
 	//admin
 	admin := auth.Group("")
 	admin.Use(app.adminMiddleware())

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -12,6 +12,7 @@ import Login from "./pages/Login";
 import Home from "./pages/Home";
 import Connect from "./pages/Connect";
 import Documents from "./pages/Documents";
+import Integrations from "./pages/Integrations";
 import Profile from "./pages/Profile";
 import Admin from "./pages/Admin";
 import NoMatch from "./pages/404";
@@ -35,6 +36,7 @@ export default function App() {
               <PrivateRoute exact path="/" component={Home} />
               <PrivateRoute path="/documents" component={Documents} />
               <PrivateRoute path="/connect" component={Connect} />
+              <PrivateRoute path="/integrations" component={Integrations} />
               <PrivateRoute path="/profile" component={Profile} />
               <PrivateRoute path="/admin" roles={[Role.Admin]} component={Admin} />
 

--- a/ui/src/components/Navigation.js
+++ b/ui/src/components/Navigation.js
@@ -34,6 +34,11 @@ const NavigationBar = () => {
                   </Nav.Link>
                 </Nav.Item>
                 <Nav.Item>
+                  <Nav.Link as={NavLink} to="/integrations">
+                    Integrations
+                  </Nav.Link>
+                </Nav.Item>
+                <Nav.Item>
                   <Nav.Link as={NavLink} to="/connect">
                     Connect
                   </Nav.Link>

--- a/ui/src/pages/Integrations/IntegrationModal.js
+++ b/ui/src/pages/Integrations/IntegrationModal.js
@@ -1,0 +1,172 @@
+import React, { useState } from "react";
+import Form from "react-bootstrap/Form";
+import { Button, Card } from "react-bootstrap";
+import apiService from "../../services/api.service";
+
+import { Alert } from "react-bootstrap";
+
+export default function IntegrationModal(params) {
+  const { integration, onSave, headerText, onClose } = params;
+
+  const [formErrors, setFormErrors] = useState({});
+  const [integrationForm, setIntegrationForm] = useState({
+    name: integration?.Name,
+    provider: integration?.Provider,
+    email: integration?.email,
+    username: integration?.Username,
+    password: integration?.Password,
+    address: integration?.Address,
+    insecure: integration?.Insecure,
+    accesstoken: integration?.Accesstoken,
+    path: integration?.Path,
+  });
+
+  function handleChange({ target }) {
+    setIntegrationForm({ ...integrationForm, [target.name]: target.value });
+  }
+
+  function formIsValid() {
+    const _errors = {};
+
+    if (!integrationForm.name) _errors.error = "name is required";
+
+    setFormErrors(_errors);
+
+    return Object.keys(_errors).length === 0;
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+
+    if (!formIsValid()) return;
+
+    try {
+      await apiService.updateintegration({
+        id: integration.ID,
+        name: integrationForm.name,
+        provider: integrationForm.provider,
+        username: integrationForm.username,
+        password: integrationForm.password,
+        address: integrationForm.address,
+        insecure: integrationForm.insecure,
+        accesstoken: integrationForm.accesstoken,
+        path: integrationForm.path,
+      });
+      onSave();
+    } catch (e) {
+      setFormErrors({ error: e.toString() });
+    }
+  }
+
+  if (!integration) return null;
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Card>
+        <Card.Header>
+          <span>{headerText}</span>
+        </Card.Header>
+        <Card.Body>
+          <div>
+            <Alert variant="danger" hidden={!formErrors.error}>
+              <Alert.Heading>An Error Occurred</Alert.Heading>
+              {formErrors.error}
+            </Alert>
+
+            <Form.Label>IntegrationID</Form.Label>
+            <Form.Control
+              className="font-weight-bold"
+              placeholder=""
+              value={integration.ID}
+              disabled
+            />
+
+            <Form.Label>Provider</Form.Label>
+            <Form.Control
+              as="select"
+              name="provider"
+              value={integrationForm.provider}
+              onChange={handleChange}
+            >
+              <option value="localfs">Directory in file system</option>
+              <option value="webdav">WebDAV</option>
+              <option value="dropbox">Dropbox</option>
+            </Form.Control>
+
+            <Form.Label>Name</Form.Label>
+            <Form.Control
+              placeholder="Integration name"
+              value={integrationForm.name}
+              name="name"
+              onChange={handleChange}
+            />
+
+            {integrationForm.provider === "webdav" && (
+              <>
+                <Form.Label>Address</Form.Label>
+                <Form.Control
+                  placeholder="Server URL"
+                  value={integrationForm.address}
+                  name="address"
+                  onChange={handleChange}
+                />
+              </>
+            )}
+            {integrationForm.provider === "webdav" && (
+              <>
+                <Form.Label>Username</Form.Label>
+                <Form.Control
+                  placeholder="Username"
+                  value={integrationForm.username}
+                  name="username"
+                  onChange={handleChange}
+                />
+              </>
+            )}
+            {integrationForm.provider === "webdav" && (
+              <>
+                <Form.Label>Password</Form.Label>
+                <Form.Control
+                  type="password"
+                  placeholder="Password"
+                  value={integrationForm.password}
+                  name="password"
+                  onChange={handleChange}
+                />
+              </>
+            )}
+
+            {integrationForm.provider === "localfs" && (
+              <>
+                <Form.Label>Path</Form.Label>
+                <Form.Control
+                  placeholder="Path"
+                  value={integrationForm.path}
+                  name="path"
+                  onChange={handleChange}
+                />
+              </>
+            )}
+
+            {integrationForm.provider === "dropbox" && (
+              <>
+                <Form.Label>Access Token</Form.Label>
+                <Form.Control
+                  placeholder="Access Token"
+                  value={integrationForm.accesstoken}
+                  name="accesstoken"
+                  onChange={handleChange}
+                />
+              </>
+            )}
+          </div>
+        </Card.Body>
+        <Card.Footer style={{ display: "flex", flex: "10", gap: "15px" }}>
+          <Button variant="primary" type="submit">
+            Save
+          </Button>
+          <Button variant="secondary" onClick={onClose}>Cancel</Button>
+        </Card.Footer>
+      </Card>
+    </Form>
+  );
+}

--- a/ui/src/pages/Integrations/NewIntegrationModal.js
+++ b/ui/src/pages/Integrations/NewIntegrationModal.js
@@ -1,0 +1,153 @@
+import React, { useState } from "react";
+import Form from "react-bootstrap/Form";
+import { Button, Card } from "react-bootstrap";
+import apiService from "../../services/api.service";
+
+import { Alert } from "react-bootstrap";
+
+export default function IntegrationProfileModal(params) {
+  const { onSave, onClose } = params;
+
+  const [formErrors, setFormErrors] = useState({});
+  const [formInfo, setFormInfo] = useState({});
+  const [integrationForm, setIntegrationForm] = useState({
+    name: "",
+    provider: "localfs",
+  });
+
+  function handleChange({ target }) {
+    setIntegrationForm({ ...integrationForm, [target.name]: target.value });
+  }
+
+  function formIsValid() {
+    const _errors = {};
+
+    if (!integrationForm.name) _errors.error = "name is required";
+
+    if (!integrationForm.provider) _errors.error = "provider is required";
+
+    setFormErrors(_errors);
+
+    return Object.keys(_errors).length === 0;
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+
+    if (!formIsValid()) return;
+
+    try {
+      await apiService.createintegration(integrationForm);
+      setFormInfo({ message: "Created" });
+      onSave();
+    } catch (e) {
+      setFormErrors({ error: e.toString() });
+    }
+  }
+
+  return (
+    <Form onSubmit={handleSubmit} autoComplete="off">
+      <Card>
+        <Card.Header>
+          <span>New Integration</span>
+        </Card.Header>
+        <Card.Body>
+          <Alert variant="danger" hidden={!formErrors.error}>
+            <Alert.Heading>An Error Occurred</Alert.Heading>
+            {formErrors.error}
+          </Alert>
+
+          <Alert variant="info" hidden={!formInfo.message}>
+            {formInfo.message}
+          </Alert>
+
+          <Form.Label>Name</Form.Label>
+          <Form.Control
+            placeholder="Integration name"
+            value={integrationForm.name}
+            name="name"
+            autofocus
+            onChange={handleChange}
+          />
+
+          <Form.Label>Provider</Form.Label>
+          <Form.Select
+            name="provider"
+            value={integrationForm.provider}
+            onChange={handleChange}
+            className="mb-1"
+          >
+            <option value="localfs">Directory in file system</option>
+            <option value="webdav">WebDAV</option>
+            <option value="dropbox">Dropbox</option>
+          </Form.Select>
+
+          {integrationForm.provider === "webdav" && (
+            <>
+              <Form.Label>Address</Form.Label>
+              <Form.Control
+                placeholder="Server URL"
+                value={integrationForm.address}
+                name="address"
+                onChange={handleChange}
+              />
+            </>
+          )}
+          {integrationForm.provider === "webdav" && (
+            <>
+              <Form.Label>Username</Form.Label>
+              <Form.Control
+                placeholder="Username"
+                value={integrationForm.username}
+                name="username"
+                onChange={handleChange}
+              />
+            </>
+          )}
+          {integrationForm.provider === "webdav" && (
+            <>
+              <Form.Label>Password</Form.Label>
+              <Form.Control
+                type="password"
+                placeholder="Password"
+                value={integrationForm.password}
+                name="password"
+                onChange={handleChange}
+              />
+            </>
+          )}
+
+          {integrationForm.provider === "localfs" && (
+            <>
+              <Form.Label>Path</Form.Label>
+              <Form.Control
+                placeholder="Path"
+                value={integrationForm.path}
+                name="path"
+                onChange={handleChange}
+              />
+            </>
+          )}
+
+          {integrationForm.provider === "dropbox" && (
+            <>
+              <Form.Label>Access Token</Form.Label>
+              <Form.Control
+                placeholder="Access Token"
+                value={integrationForm.accesstoken}
+                name="accesstoken"
+                onChange={handleChange}
+              />
+            </>
+          )}
+        </Card.Body>
+        <Card.Footer style={{ display: "flex", gap: "15px" }}>
+          <Button variant="primary" type="submit">
+            Save
+          </Button>
+          <Button variant="secondary" onClick={onClose}>Close</Button>
+        </Card.Footer>
+      </Card>
+    </Form>
+  );
+}

--- a/ui/src/pages/Integrations/index.jsx
+++ b/ui/src/pages/Integrations/index.jsx
@@ -1,0 +1,116 @@
+import React, {useState} from "react";
+import useFetch from "../../hooks/useFetch";
+import Spinner from "../../components/Spinner";
+import {Alert, Button, Card, Container, Modal, Table} from "react-bootstrap";
+import IntegrationModal from "./IntegrationModal";
+import NewIntegrationModal from "./NewIntegrationModal";
+import apiService from "../../services/api.service";
+import { toast } from "react-toastify";
+const integrationListUrl = "integrations";
+
+const NewIntegration = 1;
+const UpdateIntegration = 2;
+const Integrations = () => {
+  const [index, setIndex] = useState(0);
+  const { data: integrationList, error, loading } = useFetch(`${integrationListUrl}`, index);
+  const [ state, setState ] = useState({showModal: 0, modalIntegration: null});
+  const refresh = () =>{
+    setIndex(previous => previous+1)
+  }
+
+  function openModal(index: number) {
+    if (!integrationList) return;
+    let integration = integrationList[index];
+    setState({
+      showModal: UpdateIntegration,
+      modalIntegration: integration,
+    });
+  }
+  function closeModal() {
+    setState({
+      showModal: 0,
+      modalIntegration: null,
+    });
+  }
+
+  if (loading) {
+    return <Spinner />
+  }
+
+  if (error) {
+    return (
+        <Alert variant="danger">
+            <Alert.Heading>An Error Occurred</Alert.Heading>
+            {`Error ${error.status}: ${error.statusText}`}
+        </Alert>
+    );
+  }
+
+  const newIntegration = e => {
+    setState({
+      showModal: NewIntegration,
+    });
+  }
+
+  const onSave  = () => {
+    closeModal();
+    refresh();
+  }
+
+  const remove = async (e, id, name) => {
+    e.preventDefault()
+    e.stopPropagation()
+    if (!window.confirm(`Are you sure you want to delete integration: ${name}?`))
+      return false
+
+    try{
+      await apiService.deleteintegration(id)
+      refresh()
+    } catch(e){
+        toast.error('Error:'+ e)
+    }
+  }
+
+  return (
+    <Container>
+      <h3>Integrations</h3>
+      <Card>
+        <Table striped bordered hover className="mb-0">
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>IntegrationId</th>
+              <th>Name</th>
+              <th>Provider</th>
+              <th><Button onClick={newIntegration}>New Integration</Button></th>
+            </tr>
+          </thead>
+          <tbody>
+            {!integrationList.length && (
+              <tr>
+                <td colspan="5" class="text-center">No integration</td>
+              </tr>
+            )}
+            {integrationList.map((i, index) => (
+              <tr key={i.ID} onClick={() => openModal(index)} style={{ cursor: "pointer" }}>
+                <td>{index}</td>
+                <td>{i.ID}</td>
+                <td>{i.Name}</td>
+                <td>{i.Provider}</td>
+                <td><Button variant="danger" onClick={(e) => remove(e,i.ID,i.Name)}>Delete</Button></td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+        <Modal show={state.showModal === UpdateIntegration} onHide={closeModal} className="transparent-modal">
+          <IntegrationModal integration={state.modalIntegration} onSave={onSave} onClose={closeModal} headerText={`Change Integration: ${state.modalIntegration?.Name}`} />
+        </Modal>
+        <Modal show={state.showModal === NewIntegration} onHide={closeModal} className="transparent-modal">
+          <NewIntegrationModal onSave={onSave} onClose={closeModal} />
+        </Modal>
+      </Card>
+    </Container>
+  );
+};
+
+export default Integrations;

--- a/ui/src/services/api.service.js
+++ b/ui/src/services/api.service.js
@@ -127,6 +127,36 @@ class ApiServices {
       headers: this.header(),
     }).then((r) => handleError(r));
   }
+
+  listintegration() {
+    return fetch(`${constants.ROOT_URL}/integrations`, {
+      method: "GET",
+      headers: this.header(),
+    }).then((r) => {
+      handleError(r);
+      return r.json();
+    });
+  }
+  updateintegration(integration) {
+    return fetch(`${constants.ROOT_URL}/integrations/${integration.id}`, {
+      method: "PUT",
+      headers: this.header(),
+      body: JSON.stringify(integration),
+    }).then((r) => handleError(r));
+  }
+  createintegration(integration) {
+    return fetch(`${constants.ROOT_URL}/integrations`, {
+      method: "POST",
+      headers: this.header(),
+      body: JSON.stringify(integration),
+    }).then((r) => handleError(r));
+  }
+  deleteintegration(integrationid) {
+    return fetch(`${constants.ROOT_URL}/integrations/${integrationid}`, {
+      method: "DELETE",
+      headers: this.header(),
+    }).then((r) => handleError(r));
+  }
 }
 
 function removeUser(){


### PR DESCRIPTION
Hi!

I would like to introduce [Google Drive integration](https://github.com/ddvk/rmfakecloud/pull/241), but this requires to retrieve an oauth token to access the Google API. The easiest way to retrieve the token is by letting the user making the authentication in its browser and then retrieve the token, so I first introduce an interface to manage integrations, based on the user management page.

Second commit is to sort integrations alphabetically.

![image](https://github.com/user-attachments/assets/3d449baa-543f-47fa-b717-84361017ce6e)
![image](https://github.com/user-attachments/assets/c4c1b10c-341e-4282-9df0-18a311781fc2)
