### PR TITLE
Add routes for sync v3.4

### DIFF
--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -127,5 +127,8 @@ func (app *App) registerRoutes(router *gin.Engine) {
 		authRoutes.POST("/sync/v2/signed-urls/downloads", app.blobStorageDownload)
 		authRoutes.POST("/sync/v2/signed-urls/uploads", app.blobStorageUpload)
 		authRoutes.POST("/sync/v2/sync-complete", app.syncCompleteV2)
+
+		authRoutes.GET("/sync/v3/root", app.syncGetRootV3)
+		authRoutes.PUT("/sync/v3/root", app.syncUpdateRootV3)
 	}
 }

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -136,6 +136,12 @@ type SyncCompletedRequestV2 struct {
 	Generation int64 `json:"generation"`
 }
 
+// SyncRootV3
+type SyncRootV3 struct {
+	Generation int64  `json:"generation"`
+	Hash       string `json:"hash"`
+}
+
 // IntegrationsResponse integrations
 type IntegrationsResponse struct {
 	Integrations []Integration `json:"integrations"`


### PR DESCRIPTION
Hi!

The release 3.4 introduce 2 new routes required to handle the root hash index.

Instead of changing the root index as part of a blob request, they create a new route `/sync/v3/root` with the following content:

```json
{
    "generation": 4242,
    "hash": "0123456789abcdef0123456789abcdef"
}
```

A `PUT` is called when a new hash should be stored (with `generation` inchanged), and a `GET` permit to retrieves the current generation and hash.