### PR TITLE
Add sync routes for v3.7

### DIFF
--- a/internal/app/claims.go
+++ b/internal/app/claims.go
@@ -30,7 +30,7 @@ type UserClaims struct {
 type Auth0profile struct {
 	UserID        string `json:"UserID"`
 	IsSocial      bool
-	ClientID      string `json:"ClientID"`
+	ClientID      string `json:"ClientID,omitempty"`
 	Connection    string
 	Name          string `json:"Name"`
 	Nickname      string `json:"NickName"`
@@ -38,7 +38,7 @@ type Auth0profile struct {
 	FamilyName    string
 	Email         string
 	EmailVerified bool
-	Picture       string
+	Picture       string `json:"Picture,omitempty"`
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
 }

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -759,6 +759,21 @@ func (app *App) syncGetRootV3(c *gin.Context) {
 	})
 }
 
+func (app *App) blobStorageRead(c *gin.Context) {
+	uid := c.GetString(userIDKey)
+	blobID := common.ParamS(fileKey, c)
+
+	reader, _, size, err := app.blobStorer.LoadBlob(uid, blobID)
+	if err != nil {
+		log.Error(err)
+		c.AbortWithStatus(http.StatusInternalServerError)
+		return
+	}
+	defer reader.Close()
+
+	c.DataFromReader(http.StatusOK, size, "application/octet-stream", reader, nil)
+}
+
 func (app *App) integrationsGetMetadata(c *gin.Context) {
 	var metadata messages.IntegrationMetadata
 	metadata.Thumbnail = ""

--- a/internal/app/middleware.go
+++ b/internal/app/middleware.go
@@ -14,10 +14,11 @@ import (
 )
 
 const (
-	authLog     = "[auth-middleware]"
-	requestLog  = "[requestlogging-middleware]"
-	syncDefault = "sync:default"
-	syncNew     = "sync:tortoise"
+	authLog        = "[auth-middleware]"
+	requestLog     = "[requestlogging-middleware]"
+	syncDefault    = "sync:default"
+	syncNew        = "sync:tortoise"
+	syncNewLimited = "sync:fox" // Display cloud limit messages
 )
 
 func (app *App) authMiddleware() gin.HandlerFunc {
@@ -35,7 +36,7 @@ func (app *App) authMiddleware() gin.HandlerFunc {
 
 		var isSync15 = false
 		for _, s := range scopes {
-			if s == syncNew {
+			if s == syncNew || s == syncNewLimited {
 				isSync15 = true
 				break
 			}

--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -130,5 +130,6 @@ func (app *App) registerRoutes(router *gin.Engine) {
 
 		authRoutes.GET("/sync/v3/root", app.syncGetRootV3)
 		authRoutes.PUT("/sync/v3/root", app.syncUpdateRootV3)
+		authRoutes.GET("/sync/v3/files/:"+fileKey, app.blobStorageRead)
 	}
 }


### PR DESCRIPTION
Hi,

There are new things in the release 3.7.

We have new routes to retrieve files and metadata. And apparently it seems to have a new permission/scope in the JWT.

The new route I was able to identify is `/sync/v3/files/<FILE-HASH>`. I think I handle it the right way (but I'm unable to finish the sync process due to the JWT issue.

For the JWT part, the server is spammed with requests on. We can see this in the logs:

```
time="2023-10-17T19:24:33Z" level=info msg="Using sync 1.5"
time="2023-10-17T19:24:33Z" level=info msg="setting scopes: intgr screenshare hwcmail:-1 mail:-1 sync:tortoise"
time="2023-10-17T19:24:33Z" level=info msg="[GIN] 2023/10/17 - 19:24:33 | 200 |    3.611147ms |      172.17.0.1 | POST     \"/token/json/2/user/new\""
```

```
Oct 17 19:13:10 reMarkable xochitl[1981]: 19:13:10.002 rm.network.usertoken     Scheduled token update at 2023-10-18 19:08:09, 86098997ms from now (scheduleUpdate /__w/xochitl/xochitl/src/network/src/usertoken.cpp:139)
Oct 17 19:13:10 reMarkable xochitl[1981]: 19:13:10.003 rm.network.usertoken     UserToken: setting a new userToken ("fqKdbGciDdJIUzd1QiIe"...) (setUserToken /__w/xochitl/xochitl/src/network/src/usertoken.cpp:74)
```

I'm trying to activate a cloud account on the official remarkable website, but for the moment it's not a success.

Can someone share the decoded payload (using https://jwt.io/) of a JWT user token, with personal information redacted?