### PR TITLE
New route for 3.8 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This is a replacement of the cloud, in case you want to sync/backup your files a
 ## [Docs](https://ddvk.github.io/rmfakecloud/)
 
 ## NB
+The current release of rmfakecloud support SW <= 3.8.2. Newer releases have not been tested yet.
+
 For Tablet SW > 3.X, rendering of the notebooks is not yet supported.
 
 ## Breaking Changes

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -774,6 +774,23 @@ func (app *App) blobStorageRead(c *gin.Context) {
 	c.DataFromReader(http.StatusOK, size, "application/octet-stream", reader, nil)
 }
 
+func (app *App) blobStorageWrite(c *gin.Context) {
+	uid := c.GetString(userIDKey)
+	blobID := common.ParamS(fileKey, c)
+
+	newgeneration, err := app.blobStorer.StoreBlob(uid, blobID, c.Request.Body, 0)
+	if err != nil {
+		log.Error(err)
+		c.AbortWithStatus(http.StatusInternalServerError)
+		return
+	}
+
+	c.JSON(http.StatusOK, messages.SyncRootV3{
+		Generation: newgeneration,
+		Hash:       string(blobID),
+	})
+}
+
 func (app *App) integrationsGetMetadata(c *gin.Context) {
 	var metadata messages.IntegrationMetadata
 	metadata.Thumbnail = ""

--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -131,5 +131,6 @@ func (app *App) registerRoutes(router *gin.Engine) {
 		authRoutes.GET("/sync/v3/root", app.syncGetRootV3)
 		authRoutes.PUT("/sync/v3/root", app.syncUpdateRootV3)
 		authRoutes.GET("/sync/v3/files/:"+fileKey, app.blobStorageRead)
+		authRoutes.PUT("/sync/v3/files/:"+fileKey, app.blobStorageWrite)
 	}
 }


### PR DESCRIPTION
I tried to introduce this exact route in 3.7, but as it was not used and I couldn't verify what return was expected.

The route is now used in the 3.8 release. It seems to return the same content as expected by the `/sync/v3/root` route.

If someone can record a official conversation with a `PUT /sync/v3/files/...`, it would help.