### PR TITLE
Make authentication scopes dynamic

### DIFF
--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -159,6 +159,11 @@ func (app *App) newUserToken(c *gin.Context) {
 	} else {
 		scopes = append(scopes, syncDefault)
 	}
+
+	if len(user.AdditionalScopes) > 0 {
+		scopes = append(scopes, user.AdditionalScopes...)
+	}
+
 	scopesStr := strings.Join(scopes, " ")
 	log.Info("setting scopes: ", scopesStr)
 

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -143,7 +143,15 @@ func (app *App) newUserToken(c *gin.Context) {
 		return
 	}
 
-	scopes := []string{"intgr", "screenshare", "hwcmail:-1", "mail:-1"}
+	scopes := []string{"intgr", "screenshare"}
+
+	if app.cfg.HWRApplicationKey != "" && app.cfg.HWRHmac != "" {
+		scopes = append(scopes, "hwcmail:-1")
+	}
+
+	if app.cfg.SMTPConfig != nil {
+		scopes = append(scopes, "mail:-1")
+	}
 
 	if user.Sync15 {
 		log.Info("Using sync 1.5")

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -47,9 +47,13 @@ type User struct {
 	FamilyName    string
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
-	IsAdmin       bool
-	// Sync15 if the user should use this sync type (which uses a lot less bandwidth)
-	Sync15       bool
+	// IsAdmin indicates if the user can managed others users in this instance.
+	IsAdmin bool
+	// Sync15 if the user should use this sync type (which uses a lot less bandwidth).
+	Sync15 bool
+	// AdditionalScopes is a list of scopes to add to the user session.
+	AdditionalScopes []string
+	// Integrations stores the list of "Integrations" as shown on the tablet.
 	Integrations []IntegrationConfig
 }
 


### PR DESCRIPTION
This pull request aims to disable handwriting recognition and email sending if the settings are not filled correctly.

Moreover, I added a new user field: `AdditionalScopes`, they'll be given to this user when it'll request a new token, in addition to official scopes. (See details [on Discord](https://discord.com/channels/385916768696139794/385916768696139799/1171867843592212581).)