### PR TITLE
route required by the new version of the iOS app

### DIFF
--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -34,6 +34,18 @@ func (app *App) registerRoutes(router *gin.Engine) {
 			"webapp":        endpoint,
 		})
 	})
+  router.GET("/discovery/v1/webapp", func(c *gin.Context) {                                                                                                       
+                endpoint, err := app.MyEndpoint()                                                                                                                 
+                if err != nil {                                                                                                                                   
+                        log.Warn("endpoint error:", err.Error())                                                                                                  
+                        c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"err": err.Error()})                                                          
+                        return                                                                                                                                    
+                }                                                                                                                                                 
+          c.JSON(http.StatusOK, gin.H{                                                                                                                            
+                  "Status": "OK",                                                                                                                                 
+                  "Host": endpoint,                                                                                                                               
+          })                                                                                                                                                      
+  })                                                                                                                                                              
 
 	router.GET("/health", func(c *gin.Context) {
 		count := app.hub.ClientCount()


### PR DESCRIPTION
a newer version of the iOS app expects to receive the endpoint info from this route.
this is the answer from the official server (https://internal.cloud.remarkable.com/discovery/v1/webapp):
`{
    "Status" : "OK",
    "Host" : "webapp.cloud.remarkable.com"
}
`