### PR TITLE
New routes for v3.10 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a replacement of the cloud, in case you want to sync/backup your files a
 ## [Docs](https://ddvk.github.io/rmfakecloud/)
 
 ## NB
-The current release of rmfakecloud support file synchronization for SW <= 3.9.3. Newer releases have not been tested yet.
+The current release of rmfakecloud support file synchronization for SW <= 3.10.2. Newer releases have not been tested yet.
 
 For Tablet SW > 3.X, rendering of the notebooks [is not yet supported](https://github.com/ddvk/rmfakecloud/issues/255).
 

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -779,6 +779,35 @@ func (app *App) syncGetRootV3(c *gin.Context) {
 	})
 }
 
+func (app *App) checkFilesPresence(c *gin.Context) {
+	uid := c.GetString(userIDKey)
+	var req messages.CheckFiles
+	if err := c.ShouldBindJSON(&req); err != nil {
+		log.Error(err)
+		badReq(c, err.Error())
+		return
+	}
+
+	mfs := messages.MissingFiles{}
+
+	for _, fileid := range req.Files {
+		_, _, err := app.blobStorer.GetBlobURL(uid, fileid, false)
+		if err != nil {
+			mfs.MissingFiles = append(mfs.MissingFiles, fileid)
+		}
+	}
+
+	c.JSON(http.StatusOK, mfs)
+}
+
+func (app *App) checkMissingBlob(c *gin.Context) {
+	mhs := messages.MissingHashes{}
+
+	// TODO
+
+	c.JSON(http.StatusOK, mhs)
+}
+
 func (app *App) blobStorageRead(c *gin.Context) {
 	uid := c.GetString(userIDKey)
 	blobID := common.ParamS(fileKey, c)

--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -91,6 +91,16 @@ func (app *App) registerRoutes(router *gin.Engine) {
 		}
 		c.Status(http.StatusOK)
 	})
+	router.POST("/v2/reports", func(c *gin.Context) {
+		_, err := ioutil.ReadAll(c.Request.Body)
+
+		if err != nil {
+			log.Warn("cant parse telemetry, ignored")
+			c.Status(http.StatusOK)
+			return
+		}
+		c.Status(http.StatusOK)
+	})
 
 	//routes needing api authentitcation
 	authRoutes := router.Group("/")
@@ -144,5 +154,8 @@ func (app *App) registerRoutes(router *gin.Engine) {
 		authRoutes.PUT("/sync/v3/root", app.syncUpdateRootV3)
 		authRoutes.GET("/sync/v3/files/:"+fileKey, app.blobStorageRead)
 		authRoutes.PUT("/sync/v3/files/:"+fileKey, app.blobStorageWrite)
+
+		authRoutes.POST("/sync/v3/check-files", app.checkFilesPresence)
+		authRoutes.GET("/sync/v3/missing", app.checkMissingBlob)
 	}
 }

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -142,6 +142,20 @@ type SyncRootV3 struct {
 	Hash       string `json:"hash,omitempty"`
 }
 
+type CheckFiles struct {
+	Filename string   `json:"filename"`
+	Files    []string `json:"files"`
+	Reason   string   `json:"reason"`
+}
+
+type MissingFiles struct {
+	MissingFiles []string `json:"missingFiles"`
+}
+
+type MissingHashes struct {
+	Hashes []string `json:"hashes"`
+}
+
 // IntegrationsResponse integrations
 type IntegrationsResponse struct {
 	Integrations []Integration `json:"integrations"`


### PR DESCRIPTION
In order to see the archive function to work, we need to implement the `/sync/v3/check-files` route.

Here is the input:
```json
{
    "filename": "a7be6e0ea961-453b-5d54-b76e-b939beb9",
    "files": [
        "a7be6e0ea9618b3421b3131f1453b3f6e8453b5b01453bdccc7bf123b4bebeb9",
        "84eae55a21242bc1b8da64209161ed97ea2927a24ec434732d363453ab3ad9d4",
        "3d4b122055d556f2cd0e936e4dd264817e17196cb828e886cc7ae6d298268b45",
        "ebaef2a30e1d43068726d14c31b4ce763585c1f942be7cd2f8843d55f99fe6f8",
        "ba023d47bd42294fd3f64869507a96cea932b8157d14f1c315c84bba87d6e9a4"
    ],
    "reason": "Archive"
}
```

I also see a reason "Logout" when we try to unpair the device from cloud.

The current implementation doesn't return anything and it works. (As we didn't delete any file, the archived file can be retrieved as always.)