### PR TITLE
email: set reply-to header

### DIFF
--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -32,7 +32,7 @@ To be able to send email from your reMarkable, fill the following variables:
 | `RM_SMTP_SERVER`       | The SMTP server address in  host:port format |
 | `RM_SMTP_USERNAME`     | The username/email for login |
 | `RM_SMTP_PASSWORD`     | Plaintext password (application password should work) |
-| `RM_SMTP_FROM`         | Custom `From:` header for the mails (eg. 'ReMarkable self-hosted <remarkable@my.example.net>') |
+| `RM_SMTP_FROM`         | Custom `From:` header for the mails (eg. `ReMarkable self-hosted <remarkable@my.example.net>`). If this override is set, the user's email address is instead put as `Reply-To` |
 | `RM_SMTP_HELO`         | Custom HELO, if your email provider needs it |
 | `RM_SMTP_NOTLS` | don't use tls |
 | `RM_SMTP_STARTTLS` | use starttls command, should be combined with NOTLS. in most cases port 587 should be used |

--- a/internal/email/smtp.go
+++ b/internal/email/smtp.go
@@ -40,7 +40,7 @@ type SMTPConfig struct {
 type Builder struct {
 	From    *mail.Address
 	To      []*mail.Address
-	ReplyTo string
+	ReplyTo *mail.Address
 	Body    string
 	Subject string
 
@@ -186,6 +186,9 @@ func (b *Builder) Send(cfg *SMTPConfig) (err error) {
 	//basic email headers
 	msgBuilder.WriteString(fmt.Sprintf("From: %s\r\n", utf8encode(b.From.String())))
 	msgBuilder.WriteString(fmt.Sprintf("To: %s\r\n", utf8encode(to)))
+	if b.ReplyTo != nil {
+		msgBuilder.WriteString(fmt.Sprintf("Reply-To: %s\r\n", utf8encode(b.ReplyTo.String())))
+	}
 	msgBuilder.WriteString(fmt.Sprintf("Subject: %s\r\n", utf8encode(b.Subject)))
 	msgBuilder.WriteString("MIME-Version: 1.0\r\n")
 	msgBuilder.WriteString(fmt.Sprintf("Content-Type: multipart/mixed; boundary=\"%s\"\r\n", delimeter))


### PR DESCRIPTION
This sets the `Reply-To` header with the user's address on outgoing
emails when a `FROM` override is configured. This avoids unintended
replies to "no-reply" addresses for example.
