### PR TITLE
sync/v4 expects to return an empty root instead of 404

### DIFF
--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -158,6 +158,6 @@ func (app *App) registerRoutes(router *gin.Engine) {
 		authRoutes.POST("/sync/v3/check-files", app.checkFilesPresence)
 		authRoutes.GET("/sync/v3/missing", app.checkMissingBlob)
 
-		authRoutes.GET("/sync/v4/root", app.syncGetRootV3)
+		authRoutes.GET("/sync/v4/root", app.syncGetRootV4)
 	}
 }


### PR DESCRIPTION
In this patch, I tried do fix issues reported on the initial synchronization, when the account is new and no sync happen before.

I was able to test the creation of a new account with the sync/v3, it works as expected, but the changes between v3 and v4 seems to be related to how the function behaves for new accounts: https://github.com/ddvk/rmfakecloud/issues/311#issuecomment-2271359544 https://github.com/ddvk/rmfakecloud/issues/326 https://github.com/ddvk/rmfakecloud/issues/270#issuecomment-2351103545 