### PR TITLE
Bunch of small fixes

### DIFF
--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -898,19 +898,14 @@ func (app *App) blobStorageWrite(c *gin.Context) {
 	hash := c.GetHeader(common.CRC32CHashHeader)
 	log.Debugf("TODO: check/save etc. write file '%s', hash '%s'", fileName, hash)
 
-	newgeneration, err := app.blobStorer.StoreBlob(uid, blobID, c.Request.Body, 0)
+	_, err := app.blobStorer.StoreBlob(uid, blobID, c.Request.Body, 0)
 	if err != nil {
 		log.Error(err)
 		c.AbortWithStatus(http.StatusInternalServerError)
 		return
 	}
 
-	//not checked by the client yet, but who knows
-	crcJSON(c, http.StatusOK, messages.SyncRootV4Response{
-		Generation:    newgeneration,
-		Hash:          string(blobID),
-		SchemaVersion: SchemaVersion,
-	})
+	c.Status(http.StatusOK)
 }
 
 func (app *App) integrationsGetMetadata(c *gin.Context) {

--- a/internal/email/smtp.go
+++ b/internal/email/smtp.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -184,6 +185,7 @@ func (b *Builder) Send(cfg *SMTPConfig) (err error) {
 
 	msgBuilder := strings.Builder{}
 	//basic email headers
+	msgBuilder.WriteString(fmt.Sprintf("Date: %s\r\n", time.Now().Format(time.RFC1123Z)))
 	msgBuilder.WriteString(fmt.Sprintf("From: %s\r\n", utf8encode(b.From.String())))
 	msgBuilder.WriteString(fmt.Sprintf("To: %s\r\n", utf8encode(to)))
 	if b.ReplyTo != nil {

--- a/internal/storage/fs/app.go
+++ b/internal/storage/fs/app.go
@@ -144,10 +144,12 @@ func (app *App) downloadBlob(c *gin.Context) {
 
 	if scope != ReadScope {
 		c.AbortWithStatus(http.StatusForbidden)
+		return
 	}
 
 	if blobID == "" {
 		c.AbortWithStatus(http.StatusBadRequest)
+		return
 	}
 
 	log.Info("Requestng blob: ", blobID)
@@ -185,16 +187,19 @@ func (app *App) uploadBlob(c *gin.Context) {
 	err := VerifyURLParams([]string{uid, blobID, exp, scope}, exp, signature, app.cfg.JWTSecretKey)
 	if err != nil {
 		c.AbortWithStatus(http.StatusForbidden)
+		return
 	}
 	log.Info(exp, signature)
 
 	if blobID == "" {
 		c.AbortWithStatus(http.StatusBadRequest)
+		return
 	}
 
 	if scope != WriteScope {
 		log.Warn("wrong scope: " + scope)
 		c.AbortWithStatus(http.StatusForbidden)
+		return
 	}
 
 	body := c.Request.Body


### PR DESCRIPTION
I'm cleaning up some patches I made some time ago...

1. In order to let some email clients/servers to sort properly by date, the email sent by rmfakecloud needs to be dated. This adds a Date header.
2. Some missing returns after `AbortWithStatus`.
3. `PUT /sync/v3/files/` doesn't have body on success, nor crc32c:

```
$ curl -v -s -X PUT -d @file -H "x-goog-hash: crc32c=123456==" -H "Authorization: Bearer $USER_TOKEN" https://internal.cloud.remarkable.com/sync/v3/files/REDACTED
* Connected to internal.cloud.remarkable.com (34.117.147.117) port 443
> PUT /sync/v3/files/REDACTED HTTP/2
> Host: internal.cloud.remarkable.com
> x-goog-hash: crc32c=123456==
> Authorization: Bearer redacted
> Content-Length: 123
>
* upload completely sent off: 123 bytes
< HTTP/2 200
< rm-token-ttl-hint: 9876
< content-length: 0
< date: Sun, 12 Jan 2024 12:34:45 GMT
< server: Google Frontend
< x-cloud-trace-context: redacted;o=1
< traceparent: redacted
< content-type: text/html; charset=UTF-8
< x-envoy-decorator-operation: ingress PutFile
< via: 1.1 google
< alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
<
* Connection #0 to host internal.cloud.remarkable.com left intact
```