### PR TITLE
Improve integrations with metadata and debug routes

### DIFF
--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -908,9 +908,25 @@ func (app *App) blobStorageWrite(c *gin.Context) {
 }
 
 func (app *App) integrationsGetMetadata(c *gin.Context) {
-	var metadata messages.IntegrationMetadata
-	metadata.Thumbnail = ""
-	c.JSON(http.StatusOK, &metadata)
+	uid := c.GetString(userIDKey)
+	integrationID := common.ParamS(integrationKey, c)
+	fileID := common.ParamS(fileKey, c)
+
+	integrationProvider, err := integrations.GetIntegrationProvider(app.userStorer, uid, integrationID)
+	if err != nil {
+		log.Error(fmt.Errorf("can't get integration, %v", err))
+		c.AbortWithStatus(http.StatusInternalServerError)
+		return
+	}
+
+	metadata, err := integrationProvider.GetMetadata(fileID)
+	if err != nil {
+		log.Error(err)
+		c.AbortWithStatus(http.StatusInternalServerError)
+		return
+	}
+
+	c.JSON(http.StatusOK, metadata)
 }
 
 func (app *App) integrationsUpload(c *gin.Context) {

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -968,7 +968,7 @@ func (app *App) integrationsGetFile(c *gin.Context) {
 		return
 	}
 
-	reader, err := integrationProvider.Download(fileID)
+	reader, size, err := integrationProvider.Download(fileID)
 	if err != nil {
 		log.Error(err)
 		c.AbortWithStatus(http.StatusInternalServerError)
@@ -977,8 +977,9 @@ func (app *App) integrationsGetFile(c *gin.Context) {
 
 	defer reader.Close()
 
-	c.DataFromReader(http.StatusOK, -1, "application/octet-stream", reader, nil)
+	c.DataFromReader(http.StatusOK, size, "application/octet-stream", reader, nil)
 }
+
 func (app *App) integrationsList(c *gin.Context) {
 	uid := c.GetString(userIDKey)
 	integrationID := common.ParamS(integrationKey, c)

--- a/internal/integrations/dropbox.go
+++ b/internal/integrations/dropbox.go
@@ -70,8 +70,8 @@ func (d *DropBox) List(folderID string, depth int) (*messages.IntegrationFolder,
 	return response, nil
 }
 
-func (d *DropBox) Download(fileID string) (io.ReadCloser, error) {
-	return nil, nil
+func (d *DropBox) Download(fileID string) (io.ReadCloser, int64, error) {
+	return nil, 0, nil
 
 }
 func (d *DropBox) Upload(folderID, name, fileType string, reader io.ReadCloser) (string, error) {

--- a/internal/integrations/dropbox.go
+++ b/internal/integrations/dropbox.go
@@ -24,6 +24,11 @@ func newDropbox(i model.IntegrationConfig) *DropBox {
 	}
 }
 
+func (d *DropBox) GetMetadata(fileID string) (*messages.IntegrationMetadata, error) {
+	// TODO
+	return nil, nil
+}
+
 func (d *DropBox) List(folderID string, depth int) (*messages.IntegrationFolder, error) {
 
 	args := files.ListFolderArg{

--- a/internal/integrations/integrations.go
+++ b/internal/integrations/integrations.go
@@ -23,7 +23,7 @@ const (
 type IntegrationProvider interface {
 	GetMetadata(fileID string) (result *messages.IntegrationMetadata, err error)
 	List(folderID string, depth int) (result *messages.IntegrationFolder, err error)
-	Download(fileID string) (io.ReadCloser, error)
+	Download(fileID string) (io.ReadCloser, int64, error)
 	Upload(folderID, name, fileType string, reader io.ReadCloser) (string, error)
 }
 
@@ -125,7 +125,6 @@ func visitDir(root, currentPath string, depth int, parentFolder *messages.Integr
 
 			docName := strings.TrimSuffix(entryName, ext)
 			extension := strings.TrimPrefix(ext, ".")
-
 
 			file := &messages.IntegrationFile{
 				ProvidedFileType: contentType,

--- a/internal/integrations/integrations.go
+++ b/internal/integrations/integrations.go
@@ -134,7 +134,7 @@ func visitDir(root, currentPath string, depth int, parentFolder *messages.Integr
 				ID:               encodedPath,
 				FileID:           encodedPath,
 				Name:             docName,
-				Size:             int(d.Size()),
+				Size:             d.Size(),
 				SourceFileType:   contentType,
 			}
 

--- a/internal/integrations/integrations.go
+++ b/internal/integrations/integrations.go
@@ -21,6 +21,7 @@ const (
 
 // IntegrationProvider abstracts 3rd party integrations
 type IntegrationProvider interface {
+	GetMetadata(fileID string) (result *messages.IntegrationMetadata, err error)
 	List(folderID string, depth int) (result *messages.IntegrationFolder, err error)
 	Download(fileID string) (io.ReadCloser, error)
 	Upload(folderID, name, fileType string, reader io.ReadCloser) (string, error)

--- a/internal/integrations/integrations.go
+++ b/internal/integrations/integrations.go
@@ -37,12 +37,12 @@ func GetIntegrationProvider(storer storage.UserStorer, uid, integrationid string
 			continue
 		}
 		switch intg.Provider {
-		case webdavProvider:
-			return newWebDav(intg), nil
 		case dropboxProvider:
 			return newDropbox(intg), nil
 		case localfsProvider:
 			return newLocalFS(intg), nil
+		case webdavProvider:
+			return newWebDav(intg), nil
 		}
 	}
 	return nil, fmt.Errorf("integration not found or no implmentation (only webdav) %s", integrationid)

--- a/internal/integrations/localfs.go
+++ b/internal/integrations/localfs.go
@@ -26,6 +26,25 @@ func newLocalFS(i model.IntegrationConfig) *localFS {
 	}
 }
 
+func (d *localFS) GetMetadata(fileID string) (*messages.IntegrationMetadata, error) {
+	decoded, err := decodeName(fileID)
+	if err != nil {
+		return nil, err
+	}
+
+	ext := path.Ext(decoded)
+	contentType := contentTypeFromExt(ext)
+
+	return &messages.IntegrationMetadata{
+		ID:               fileID,
+		Name:             path.Base(decoded),
+		Thumbnail:        []byte{},
+		SourceFileType:   contentType,
+		ProvidedFileType: contentType,
+		FileType:         ext,
+	}, nil
+}
+
 // List populates the response
 func (d *localFS) List(folder string, depth int) (*messages.IntegrationFolder, error) {
 	response := messages.NewIntegrationFolder(folder, "")

--- a/internal/integrations/localfs.go
+++ b/internal/integrations/localfs.go
@@ -88,16 +88,23 @@ func (d *localFS) List(folder string, depth int) (*messages.IntegrationFolder, e
 	return response, nil
 }
 
-func (d *localFS) Download(fileID string) (io.ReadCloser, error) {
+func (d *localFS) Download(fileID string) (io.ReadCloser, int64, error) {
 	decoded, err := decodeName(fileID)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	localPath := path.Join(d.rootPath, path.Clean(decoded))
-	return os.Open(localPath)
 
+	st, err := os.Stat(localPath)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	res, err := os.Open(localPath)
+	return res, st.Size(), err
 }
+
 func (d *localFS) Upload(folderID, name, fileType string, reader io.ReadCloser) (id string, err error) {
 	folder := "/"
 	if folderID != rootFolder {

--- a/internal/integrations/webdav.go
+++ b/internal/integrations/webdav.go
@@ -89,12 +89,20 @@ func (w *WebDavIntegration) Upload(folderID, name, fileType string, reader io.Re
 }
 
 // Download downloads
-func (w *WebDavIntegration) Download(fileID string) (io.ReadCloser, error) {
+func (w *WebDavIntegration) Download(fileID string) (io.ReadCloser, int64, error) {
 	decoded, err := decodeName(fileID)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	return w.c.ReadStream(decoded)
+
+	st, err := w.c.Stat(decoded)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	res, err := w.c.ReadStream(decoded)
+
+	return res, st.Size(), err
 }
 
 func (w *WebDavIntegration) GetMetadata(fileID string) (*messages.IntegrationMetadata, error) {

--- a/internal/integrations/webdav.go
+++ b/internal/integrations/webdav.go
@@ -97,6 +97,25 @@ func (w *WebDavIntegration) Download(fileID string) (io.ReadCloser, error) {
 	return w.c.ReadStream(decoded)
 }
 
+func (w *WebDavIntegration) GetMetadata(fileID string) (*messages.IntegrationMetadata, error) {
+	decoded, err := decodeName(fileID)
+	if err != nil {
+		return nil, err
+	}
+
+	ext := path.Ext(decoded)
+	contentType := contentTypeFromExt(ext)
+
+	return &messages.IntegrationMetadata{
+		ID:               fileID,
+		Name:             path.Base(decoded),
+		Thumbnail:        []byte{},
+		SourceFileType:   contentType,
+		ProvidedFileType: contentType,
+		FileType:         ext,
+	}, nil
+}
+
 // List populates the response
 func (w *WebDavIntegration) List(folder string, depth int) (*messages.IntegrationFolder, error) {
 	response := messages.NewIntegrationFolder(folder, "")

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -225,8 +225,11 @@ type IntegrationFolder struct {
 }
 
 type IntegrationMetadata struct {
-	FileType  string `json:"fileType"`
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	Thumbnail string `json:"thumbnail"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	// Thumbnail is base64 encoded string of an image/png
+	Thumbnail        []byte `json:"thumbnail"`
+	SourceFileType   string `json:"sourceFileType"`
+	ProvidedFileType string `json:"providedFileType"`
+	FileType         string `json:"fileType"`
 }

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -200,7 +200,7 @@ type IntegrationFile struct {
 	ID               string    `json:"id"`
 	Name             string    `json:"name"`
 	ProvidedFileType string    `json:"providedFileType"`
-	Size             int       `json:"size"`
+	Size             int64     `json:"size"`
 	SourceFileType   string    `json:"sourceFileType"`
 }
 

--- a/internal/ui/routes.go
+++ b/internal/ui/routes.go
@@ -72,6 +72,13 @@ func (app *ReactAppWrapper) RegisterRoutes(router *gin.Engine) {
 	auth.POST("folders", app.createFolder)
 	auth.GET("documents/:docid/metadata", app.getDocumentMetadata)
 
+	// integrations
+	auth.GET("integrations", app.listIntegrations)
+	auth.POST("integrations", app.createIntegration)
+	auth.GET("integrations/:intid", app.getIntegration)
+	auth.PUT("integrations/:intid", app.updateIntegration)
+	auth.DELETE("integrations/:intid", app.deleteIntegration)
+
 	//admin
 	admin := auth.Group("")
 	admin.Use(app.adminMiddleware())

--- a/internal/ui/routes.go
+++ b/internal/ui/routes.go
@@ -79,6 +79,10 @@ func (app *ReactAppWrapper) RegisterRoutes(router *gin.Engine) {
 	auth.PUT("integrations/:intid", app.updateIntegration)
 	auth.DELETE("integrations/:intid", app.deleteIntegration)
 
+	auth.GET("integrations/:intid/explore/*path", app.exploreIntegration)
+	auth.GET("integrations/:intid/metadata/*path", app.getMetadataIntegration)
+	auth.GET("integrations/:intid/download/*path", app.downloadThroughIntegration)
+
 	//admin
 	admin := auth.Group("")
 	admin.Use(app.adminMiddleware())

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -12,6 +12,7 @@ import Login from "./pages/Login";
 import Home from "./pages/Home";
 import Connect from "./pages/Connect";
 import Documents from "./pages/Documents";
+import Integrations from "./pages/Integrations";
 import Profile from "./pages/Profile";
 import Admin from "./pages/Admin";
 import NoMatch from "./pages/404";
@@ -35,6 +36,7 @@ export default function App() {
               <PrivateRoute exact path="/" component={Home} />
               <PrivateRoute path="/documents" component={Documents} />
               <PrivateRoute path="/connect" component={Connect} />
+              <PrivateRoute path="/integrations" component={Integrations} />
               <PrivateRoute path="/profile" component={Profile} />
               <PrivateRoute path="/admin" roles={[Role.Admin]} component={Admin} />
 

--- a/ui/src/components/Navigation.js
+++ b/ui/src/components/Navigation.js
@@ -34,6 +34,11 @@ const NavigationBar = () => {
                   </Nav.Link>
                 </Nav.Item>
                 <Nav.Item>
+                  <Nav.Link as={NavLink} to="/integrations">
+                    Integrations
+                  </Nav.Link>
+                </Nav.Item>
+                <Nav.Item>
                   <Nav.Link as={NavLink} to="/connect">
                     Connect
                   </Nav.Link>

--- a/ui/src/pages/Integrations/IntegrationModal.js
+++ b/ui/src/pages/Integrations/IntegrationModal.js
@@ -1,0 +1,172 @@
+import React, { useState } from "react";
+import Form from "react-bootstrap/Form";
+import { Button, Card } from "react-bootstrap";
+import apiService from "../../services/api.service";
+
+import { Alert } from "react-bootstrap";
+
+export default function IntegrationModal(params) {
+  const { integration, onSave, headerText, onClose } = params;
+
+  const [formErrors, setFormErrors] = useState({});
+  const [integrationForm, setIntegrationForm] = useState({
+    name: integration?.Name,
+    provider: integration?.Provider,
+    email: integration?.email,
+    username: integration?.Username,
+    password: integration?.Password,
+    address: integration?.Address,
+    insecure: integration?.Insecure,
+    accesstoken: integration?.Accesstoken,
+    path: integration?.Path,
+  });
+
+  function handleChange({ target }) {
+    setIntegrationForm({ ...integrationForm, [target.name]: target.value });
+  }
+
+  function formIsValid() {
+    const _errors = {};
+
+    if (!integrationForm.name) _errors.error = "name is required";
+
+    setFormErrors(_errors);
+
+    return Object.keys(_errors).length === 0;
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+
+    if (!formIsValid()) return;
+
+    try {
+      await apiService.updateintegration({
+        id: integration.ID,
+        name: integrationForm.name,
+        provider: integrationForm.provider,
+        username: integrationForm.username,
+        password: integrationForm.password,
+        address: integrationForm.address,
+        insecure: integrationForm.insecure,
+        accesstoken: integrationForm.accesstoken,
+        path: integrationForm.path,
+      });
+      onSave();
+    } catch (e) {
+      setFormErrors({ error: e.toString() });
+    }
+  }
+
+  if (!integration) return null;
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Card>
+        <Card.Header>
+          <span>{headerText}</span>
+        </Card.Header>
+        <Card.Body>
+          <div>
+            <Alert variant="danger" hidden={!formErrors.error}>
+              <Alert.Heading>An Error Occurred</Alert.Heading>
+              {formErrors.error}
+            </Alert>
+
+            <Form.Label>IntegrationID</Form.Label>
+            <Form.Control
+              className="font-weight-bold"
+              placeholder=""
+              value={integration.ID}
+              disabled
+            />
+
+            <Form.Label>Provider</Form.Label>
+            <Form.Control
+              as="select"
+              name="provider"
+              value={integrationForm.provider}
+              onChange={handleChange}
+            >
+              <option value="localfs">Directory in file system</option>
+              <option value="webdav">WebDAV</option>
+              <option value="dropbox">Dropbox</option>
+            </Form.Control>
+
+            <Form.Label>Name</Form.Label>
+            <Form.Control
+              placeholder="Integration name"
+              value={integrationForm.name}
+              name="name"
+              onChange={handleChange}
+            />
+
+            {integrationForm.provider === "webdav" && (
+              <>
+                <Form.Label>Address</Form.Label>
+                <Form.Control
+                  placeholder="Server URL"
+                  value={integrationForm.address}
+                  name="address"
+                  onChange={handleChange}
+                />
+              </>
+            )}
+            {integrationForm.provider === "webdav" && (
+              <>
+                <Form.Label>Username</Form.Label>
+                <Form.Control
+                  placeholder="Username"
+                  value={integrationForm.username}
+                  name="username"
+                  onChange={handleChange}
+                />
+              </>
+            )}
+            {integrationForm.provider === "webdav" && (
+              <>
+                <Form.Label>Password</Form.Label>
+                <Form.Control
+                  type="password"
+                  placeholder="Password"
+                  value={integrationForm.password}
+                  name="password"
+                  onChange={handleChange}
+                />
+              </>
+            )}
+
+            {integrationForm.provider === "localfs" && (
+              <>
+                <Form.Label>Path</Form.Label>
+                <Form.Control
+                  placeholder="Path"
+                  value={integrationForm.path}
+                  name="path"
+                  onChange={handleChange}
+                />
+              </>
+            )}
+
+            {integrationForm.provider === "dropbox" && (
+              <>
+                <Form.Label>Access Token</Form.Label>
+                <Form.Control
+                  placeholder="Access Token"
+                  value={integrationForm.accesstoken}
+                  name="accesstoken"
+                  onChange={handleChange}
+                />
+              </>
+            )}
+          </div>
+        </Card.Body>
+        <Card.Footer style={{ display: "flex", flex: "10", gap: "15px" }}>
+          <Button variant="primary" type="submit">
+            Save
+          </Button>
+          <Button variant="secondary" onClick={onClose}>Cancel</Button>
+        </Card.Footer>
+      </Card>
+    </Form>
+  );
+}

--- a/ui/src/pages/Integrations/NewIntegrationModal.js
+++ b/ui/src/pages/Integrations/NewIntegrationModal.js
@@ -1,0 +1,153 @@
+import React, { useState } from "react";
+import Form from "react-bootstrap/Form";
+import { Button, Card } from "react-bootstrap";
+import apiService from "../../services/api.service";
+
+import { Alert } from "react-bootstrap";
+
+export default function IntegrationProfileModal(params) {
+  const { onSave, onClose } = params;
+
+  const [formErrors, setFormErrors] = useState({});
+  const [formInfo, setFormInfo] = useState({});
+  const [integrationForm, setIntegrationForm] = useState({
+    name: "",
+    provider: "localfs",
+  });
+
+  function handleChange({ target }) {
+    setIntegrationForm({ ...integrationForm, [target.name]: target.value });
+  }
+
+  function formIsValid() {
+    const _errors = {};
+
+    if (!integrationForm.name) _errors.error = "name is required";
+
+    if (!integrationForm.provider) _errors.error = "provider is required";
+
+    setFormErrors(_errors);
+
+    return Object.keys(_errors).length === 0;
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+
+    if (!formIsValid()) return;
+
+    try {
+      await apiService.createintegration(integrationForm);
+      setFormInfo({ message: "Created" });
+      onSave();
+    } catch (e) {
+      setFormErrors({ error: e.toString() });
+    }
+  }
+
+  return (
+    <Form onSubmit={handleSubmit} autoComplete="off">
+      <Card>
+        <Card.Header>
+          <span>New Integration</span>
+        </Card.Header>
+        <Card.Body>
+          <Alert variant="danger" hidden={!formErrors.error}>
+            <Alert.Heading>An Error Occurred</Alert.Heading>
+            {formErrors.error}
+          </Alert>
+
+          <Alert variant="info" hidden={!formInfo.message}>
+            {formInfo.message}
+          </Alert>
+
+          <Form.Label>Name</Form.Label>
+          <Form.Control
+            placeholder="Integration name"
+            value={integrationForm.name}
+            name="name"
+            autofocus
+            onChange={handleChange}
+          />
+
+          <Form.Label>Provider</Form.Label>
+          <Form.Select
+            name="provider"
+            value={integrationForm.provider}
+            onChange={handleChange}
+            className="mb-1"
+          >
+            <option value="localfs">Directory in file system</option>
+            <option value="webdav">WebDAV</option>
+            <option value="dropbox">Dropbox</option>
+          </Form.Select>
+
+          {integrationForm.provider === "webdav" && (
+            <>
+              <Form.Label>Address</Form.Label>
+              <Form.Control
+                placeholder="Server URL"
+                value={integrationForm.address}
+                name="address"
+                onChange={handleChange}
+              />
+            </>
+          )}
+          {integrationForm.provider === "webdav" && (
+            <>
+              <Form.Label>Username</Form.Label>
+              <Form.Control
+                placeholder="Username"
+                value={integrationForm.username}
+                name="username"
+                onChange={handleChange}
+              />
+            </>
+          )}
+          {integrationForm.provider === "webdav" && (
+            <>
+              <Form.Label>Password</Form.Label>
+              <Form.Control
+                type="password"
+                placeholder="Password"
+                value={integrationForm.password}
+                name="password"
+                onChange={handleChange}
+              />
+            </>
+          )}
+
+          {integrationForm.provider === "localfs" && (
+            <>
+              <Form.Label>Path</Form.Label>
+              <Form.Control
+                placeholder="Path"
+                value={integrationForm.path}
+                name="path"
+                onChange={handleChange}
+              />
+            </>
+          )}
+
+          {integrationForm.provider === "dropbox" && (
+            <>
+              <Form.Label>Access Token</Form.Label>
+              <Form.Control
+                placeholder="Access Token"
+                value={integrationForm.accesstoken}
+                name="accesstoken"
+                onChange={handleChange}
+              />
+            </>
+          )}
+        </Card.Body>
+        <Card.Footer style={{ display: "flex", gap: "15px" }}>
+          <Button variant="primary" type="submit">
+            Save
+          </Button>
+          <Button variant="secondary" onClick={onClose}>Close</Button>
+        </Card.Footer>
+      </Card>
+    </Form>
+  );
+}

--- a/ui/src/pages/Integrations/index.jsx
+++ b/ui/src/pages/Integrations/index.jsx
@@ -1,0 +1,116 @@
+import React, {useState} from "react";
+import useFetch from "../../hooks/useFetch";
+import Spinner from "../../components/Spinner";
+import {Alert, Button, Card, Container, Modal, Table} from "react-bootstrap";
+import IntegrationModal from "./IntegrationModal";
+import NewIntegrationModal from "./NewIntegrationModal";
+import apiService from "../../services/api.service";
+import { toast } from "react-toastify";
+const integrationListUrl = "integrations";
+
+const NewIntegration = 1;
+const UpdateIntegration = 2;
+const Integrations = () => {
+  const [index, setIndex] = useState(0);
+  const { data: integrationList, error, loading } = useFetch(`${integrationListUrl}`, index);
+  const [ state, setState ] = useState({showModal: 0, modalIntegration: null});
+  const refresh = () =>{
+    setIndex(previous => previous+1)
+  }
+
+  function openModal(index: number) {
+    if (!integrationList) return;
+    let integration = integrationList[index];
+    setState({
+      showModal: UpdateIntegration,
+      modalIntegration: integration,
+    });
+  }
+  function closeModal() {
+    setState({
+      showModal: 0,
+      modalIntegration: null,
+    });
+  }
+
+  if (loading) {
+    return <Spinner />
+  }
+
+  if (error) {
+    return (
+        <Alert variant="danger">
+            <Alert.Heading>An Error Occurred</Alert.Heading>
+            {`Error ${error.status}: ${error.statusText}`}
+        </Alert>
+    );
+  }
+
+  const newIntegration = e => {
+    setState({
+      showModal: NewIntegration,
+    });
+  }
+
+  const onSave  = () => {
+    closeModal();
+    refresh();
+  }
+
+  const remove = async (e, id, name) => {
+    e.preventDefault()
+    e.stopPropagation()
+    if (!window.confirm(`Are you sure you want to delete integration: ${name}?`))
+      return false
+
+    try{
+      await apiService.deleteintegration(id)
+      refresh()
+    } catch(e){
+        toast.error('Error:'+ e)
+    }
+  }
+
+  return (
+    <Container>
+      <h3>Integrations</h3>
+      <Card>
+        <Table striped bordered hover className="mb-0">
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>IntegrationId</th>
+              <th>Name</th>
+              <th>Provider</th>
+              <th><Button onClick={newIntegration}>New Integration</Button></th>
+            </tr>
+          </thead>
+          <tbody>
+            {!integrationList.length && (
+              <tr>
+                <td colspan="5" class="text-center">No integration</td>
+              </tr>
+            )}
+            {integrationList.map((i, index) => (
+              <tr key={i.ID} onClick={() => openModal(index)} style={{ cursor: "pointer" }}>
+                <td>{index}</td>
+                <td>{i.ID}</td>
+                <td>{i.Name}</td>
+                <td>{i.Provider}</td>
+                <td><Button variant="danger" onClick={(e) => remove(e,i.ID,i.Name)}>Delete</Button></td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+        <Modal show={state.showModal === UpdateIntegration} onHide={closeModal} className="transparent-modal">
+          <IntegrationModal integration={state.modalIntegration} onSave={onSave} onClose={closeModal} headerText={`Change Integration: ${state.modalIntegration?.Name}`} />
+        </Modal>
+        <Modal show={state.showModal === NewIntegration} onHide={closeModal} className="transparent-modal">
+          <NewIntegrationModal onSave={onSave} onClose={closeModal} />
+        </Modal>
+      </Card>
+    </Container>
+  );
+};
+
+export default Integrations;

--- a/ui/src/services/api.service.js
+++ b/ui/src/services/api.service.js
@@ -127,6 +127,36 @@ class ApiServices {
       headers: this.header(),
     }).then((r) => handleError(r));
   }
+
+  listintegration() {
+    return fetch(`${constants.ROOT_URL}/integrations`, {
+      method: "GET",
+      headers: this.header(),
+    }).then((r) => {
+      handleError(r);
+      return r.json();
+    });
+  }
+  updateintegration(integration) {
+    return fetch(`${constants.ROOT_URL}/integrations/${integration.id}`, {
+      method: "PUT",
+      headers: this.header(),
+      body: JSON.stringify(integration),
+    }).then((r) => handleError(r));
+  }
+  createintegration(integration) {
+    return fetch(`${constants.ROOT_URL}/integrations`, {
+      method: "POST",
+      headers: this.header(),
+      body: JSON.stringify(integration),
+    }).then((r) => handleError(r));
+  }
+  deleteintegration(integrationid) {
+    return fetch(`${constants.ROOT_URL}/integrations/${integrationid}`, {
+      method: "DELETE",
+      headers: this.header(),
+    }).then((r) => handleError(r));
+  }
 }
 
 function removeUser(){


### PR DESCRIPTION
After #240, this implements metadata retrieval, improve download (size is now given) and add some API routes to be able to explore each integrations from the UI (currently not implemented in the UI, but it's already great to debug integrations in the browser instead of the tablet).

Metadata on the tablet permit to display non-convertible files as such, ...

Implemented and tested against all existing integrations except Dropbox.