### PR TITLE
Disallow adding/editing localfs integration from ui

### DIFF
--- a/internal/integrations/integrations.go
+++ b/internal/integrations/integrations.go
@@ -13,11 +13,11 @@ import (
 )
 
 const (
-	ftpProvider     = "ftp"
-	webdavProvider  = "webdav"
-	dropboxProvider = "dropbox"
-	googleProvider  = "google"
-	localfsProvider = "localfs"
+	FtpProvider     = "ftp"
+	WebdavProvider  = "webdav"
+	DropboxProvider = "dropbox"
+	GoogleProvider  = "google"
+	LocalfsProvider = "localfs"
 )
 
 // IntegrationProvider abstracts 3rd party integrations
@@ -39,13 +39,13 @@ func GetIntegrationProvider(storer storage.UserStorer, uid, integrationid string
 			continue
 		}
 		switch intg.Provider {
-		case dropboxProvider:
+		case DropboxProvider:
 			return newDropbox(intg), nil
-		case ftpProvider:
+		case FtpProvider:
 			return newFTP(intg), nil
-		case localfsProvider:
+		case LocalfsProvider:
 			return newLocalFS(intg), nil
-		case webdavProvider:
+		case WebdavProvider:
 			return newWebDav(intg), nil
 		}
 	}
@@ -56,13 +56,13 @@ func GetIntegrationProvider(storer storage.UserStorer, uid, integrationid string
 // fix the name
 func fixProviderName(n string) string {
 	switch n {
-	case ftpProvider:
+	case FtpProvider:
 		fallthrough
-	case dropboxProvider:
+	case DropboxProvider:
 		return "Dropbox"
-	case googleProvider:
+	case GoogleProvider:
 		fallthrough
-	case webdavProvider:
+	case WebdavProvider:
 		return "GoogleDrive"
 	default:
 		return n

--- a/ui/src/pages/Integrations/IntegrationModal.js
+++ b/ui/src/pages/Integrations/IntegrationModal.js
@@ -71,7 +71,9 @@ export default function IntegrationModal(params) {
           <div>
             <Alert variant="danger" hidden={!formErrors.error}>
               <Alert.Heading>An Error Occurred</Alert.Heading>
-              {formErrors.error}
+              <div style={{'white-space': 'pre-wrap'}}>
+                {formErrors.error}
+              </div>
             </Alert>
 
             <Form.Label>IntegrationID</Form.Label>

--- a/ui/src/pages/Integrations/NewIntegrationModal.js
+++ b/ui/src/pages/Integrations/NewIntegrationModal.js
@@ -54,7 +54,9 @@ export default function IntegrationProfileModal(params) {
         <Card.Body>
           <Alert variant="danger" hidden={!formErrors.error}>
             <Alert.Heading>An Error Occurred</Alert.Heading>
-            {formErrors.error}
+            <div style={{'white-space': 'pre-wrap'}}>
+              {formErrors.error}
+            </div>
           </Alert>
 
           <Alert variant="info" hidden={!formInfo.message}>

--- a/ui/src/services/api.service.js
+++ b/ui/src/services/api.service.js
@@ -169,6 +169,9 @@ function handleError(r) {
       window.location.reload(true);
       return
     }
+    if (r.headers.get("Content-Type").startsWith("application/json")) {
+      return r.json().then(d => {throw new Error(d.error)});
+    }
     if (r.status === 400) {
       return r.text().then(text => {throw new Error(text)})
     }


### PR DESCRIPTION
To follow up https://github.com/ddvk/rmfakecloud/pull/240#issuecomment-2481664248, this addresses the possibility of adding or editing localfs directly from the UI.

Instead it shows the content to add/edit in `.userprofile`:

![image](https://github.com/user-attachments/assets/dba11d54-ccc7-4a7a-a908-1c7bdaef5b6e)

To be able to pass error directly from Go code, I added a convention that errors reported as JSON should be passed to the UI as:
```go
c.AbortWithStatusJSON(http.ErrorStatus, gin.H{"error": err.Error()})
```