### PR TITLE
Software 3.18 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ This is a replacement of the cloud, in case you want to sync/backup your files a
 ## [Docs](https://ddvk.github.io/rmfakecloud/)
 
 ## NB
-for SW 3.15 `STORAGE_URL` should not be set (or only https://some.ho.st without a port should be used)
 
-The current release of rmfakecloud support file synchronization for SW <= 3.14.1. Newer releases have not been tested yet.
+The current release of rmfakecloud support file synchronization for SW <= 3.18.1. Newer releases have not been tested yet.
+
+For SW >= 3.15 `STORAGE_URL` should not be set (or only https://some.ho.st without a port should be used)
 
 For Tablet SW > 3.X, rendering of the notebooks [is not yet supported](https://github.com/ddvk/rmfakecloud/issues/255).
 

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -143,10 +143,10 @@ func (app *App) newUserToken(c *gin.Context) {
 		return
 	}
 
-	scopes := []string{"intgr", "screenshare"}
+	scopes := []string{"intgr", "screenshare", "docedit"}
 
 	if app.cfg.HWRApplicationKey != "" && app.cfg.HWRHmac != "" {
-		scopes = append(scopes, "hwcmail:-1")
+		scopes = append(scopes, "hwcmail:-1", "hwc")
 	}
 
 	if app.cfg.SMTPConfig != nil {

--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -118,6 +118,12 @@ func (app *App) registerRoutes(router *gin.Engine) {
 		authRoutes.POST("/integrations/v1/:"+integrationKey+"/files/:"+folderKey, app.integrationsUpload)
 		authRoutes.GET("/integrations/v1/", app.integrations)
 
+		authRoutes.GET("/integrations/v2/instances", app.integrations)
+		authRoutes.GET("/integrations/v2/storage/:"+integrationKey+"/folders/:"+folderKey, app.integrationsList)
+		authRoutes.GET("/integrations/v2/storage/:"+integrationKey+"/files/:"+fileKey, app.integrationsGetFile)
+		authRoutes.GET("/integrations/v2/storage/:"+integrationKey+"/files/:"+fileKey+"/metadata", app.integrationsGetMetadata)
+		authRoutes.POST("/integrations/v2/storage/:"+integrationKey+"/files/:"+folderKey, app.integrationsUpload)
+
 		// sync15
 		authRoutes.POST("/api/v1/signed-urls/downloads", app.blobStorageDownload)
 		authRoutes.POST("/api/v1/signed-urls/uploads", app.blobStorageUpload)

--- a/internal/integrations/integrations.go
+++ b/internal/integrations/integrations.go
@@ -79,10 +79,11 @@ func List(userstorer storage.UserStorer, uid string) (*messages.IntegrationsResp
 	res := &messages.IntegrationsResponse{}
 	for _, userIntg := range user.Integrations {
 		resIntg := messages.Integration{
-			ID:       userIntg.ID,
-			Name:     userIntg.Name,
-			Provider: fixProviderName(userIntg.Provider),
-			UserID:   uid,
+			ID:           userIntg.ID,
+			Name:         userIntg.Name,
+			Provider:     fixProviderName(userIntg.Provider),
+			ProviderType: "Storage",
+			UserID:       uid,
 		}
 
 		res.Integrations = append(res.Integrations, resIntg)

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -184,12 +184,13 @@ type IntegrationsResponse struct {
 
 // Integration integrations (google,dropbox)
 type Integration struct {
-	Added    time.Time `json:"added"`
-	ID       string    `json:"id"`
-	Issues   string    `json:"issues"`
-	Name     string    `json:"name"`
-	Provider string    `json:"provider"`
-	UserID   string    `json:"userID"`
+	Added        time.Time `json:"added"`
+	ID           string    `json:"id"`
+	Issues       string    `json:"issues"`
+	Name         string    `json:"name"`
+	Provider     string    `json:"provider"`
+	ProviderType string    `json:"providerType"`
+	UserID       string    `json:"userID"`
 }
 
 type IntegrationFile struct {

--- a/internal/storage/models/metadatafile.go
+++ b/internal/storage/models/metadatafile.go
@@ -15,6 +15,7 @@ type MetadataFile struct {
 	Parent           string           `json:"parent"`
 	LastModified     string           `json:"lastModified"`
 	LastOpened       string           `json:"lastOpened"`
+	LastOpenedPage   int              `json:"lastOpenedPage"`
 	Version          int              `json:"version"`
 	Pinned           bool             `json:"pinned"`
 	Synced           bool             `json:"synced"`


### PR DESCRIPTION
The new 3.18 release introduces a new set of routes for the integrations.

It would also be interesting to find how [Methods](https://methods.remarkable.com/) works, to include custom templates in rmfakecloud. Currently I have no clue.