### PR TITLE
Software 3.20 compatibility

### DIFF
--- a/docs/usage/integrations.md
+++ b/docs/usage/integrations.md
@@ -3,8 +3,8 @@ Integration is the [feature added in reMarkable
 that allows to browse, download and upload document from location
 outside of the tablet.
 
-!!! warning
-    Integrations are still work in progress, no UI exists yet.
+You can edit your integrations using the Integration tab in the UI.
+
 
 ## WebDAV
 
@@ -54,3 +54,15 @@ integrations:
     name: [some name]
     path: /some/path/with/files
 ```
+
+
+
+## Messaging webhook
+
+Messaging are a type of integration added in software 3.17.
+
+Originally designed for Slack, this feature allows you to send your current sheet as an attachment to a Slack Canvas. The default behavior uses AI to transcribe the handwritten content on your sheet and posts both the text and the image to Slack.
+
+The Webhook integration extends this capability by sending your sheet to an external automation platform (like [n8n](https://n8n.io/), [Make.com](https://www.make.com/), ...) or custom service. This is especially useful if you want to: use your own AI pipeline or don't want AI to be involved at all, or store and process sheets in a custom backend, ...
+
+The webhook gives you full control: you decide what happens with your data.

--- a/internal/app/claims.go
+++ b/internal/app/claims.go
@@ -23,6 +23,7 @@ type UserClaims struct {
 	Scopes     string       `json:"scopes,omitempty"`
 	Version    int          `json:"version"`
 	Level      string       `json:"level"`
+	Tectonic   string       `json:"tectonic"`
 	jwt.StandardClaims
 }
 

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -195,6 +195,7 @@ func (app *App) newUserToken(c *gin.Context) {
 		DeviceID:   deviceToken.DeviceID,
 		Scopes:     scopesStr,
 		Level:      "connect",
+		Tectonic:   "eu",
 		StandardClaims: jwt.StandardClaims{
 			ExpiresAt: expirationTime.Unix(),
 			NotBefore: now.Unix(),

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -6,6 +6,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"image"
+	_ "image/png"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -921,7 +923,7 @@ func (app *App) integrationsGetMetadata(c *gin.Context) {
 	integrationID := common.ParamS(integrationKey, c)
 	fileID := common.ParamS(fileKey, c)
 
-	integrationProvider, err := integrations.GetIntegrationProvider(app.userStorer, uid, integrationID)
+	integrationProvider, err := integrations.GetStorageIntegrationProvider(app.userStorer, uid, integrationID)
 	if err != nil {
 		log.Error(fmt.Errorf("can't get integration, %v", err))
 		c.AbortWithStatus(http.StatusInternalServerError)
@@ -938,6 +940,66 @@ func (app *App) integrationsGetMetadata(c *gin.Context) {
 	c.JSON(http.StatusOK, metadata)
 }
 
+func (app *App) integrationsSendMessage(c *gin.Context) {
+	uid := userID(c)
+	integrationID := common.ParamS(integrationKey, c)
+
+	// Retrieve provider
+	integrationProvider, err := integrations.GetMessagingIntegrationProvider(app.userStorer, uid, integrationID)
+	if err != nil {
+		log.Error(fmt.Errorf("can't get integration, %v", err))
+		c.AbortWithStatus(http.StatusInternalServerError)
+		return
+	}
+
+	// Parse request body
+	form, err := c.MultipartForm()
+	if err != nil {
+		log.Error(err)
+		badReq(c, "not multiform")
+		return
+	}
+
+	attachment, ok := form.File["attachment"]
+	if !ok || len(attachment) == 0 {
+		badReq(c, "no attachment")
+		return
+	}
+
+	fd, err := attachment[0].Open()
+	if err != nil {
+		log.Error(err)
+		badReq(c, "unable to read attachment")
+		return
+	}
+	defer fd.Close()
+
+	img, _, err := image.Decode(fd)
+	if err != nil {
+		log.Error(err)
+		badReq(c, "unable to decode attachment")
+		return
+	}
+
+	if _, ok := form.Value["data"]; !ok || len(form.Value["data"]) == 0 {
+		badReq(c, "missing data")
+		return
+	}
+
+	var data messages.IntegrationMessageData
+	err = json.Unmarshal([]byte(form.Value["data"][0]), &data)
+
+	// Send the message
+	id, err := integrationProvider.SendMessage(data, img)
+	if err != nil {
+		log.Error(err)
+		internalError(c, "unable to send the message")
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"id": id})
+}
+
 func (app *App) integrationsUpload(c *gin.Context) {
 	log.Info("uploading...")
 	uid := userID(c)
@@ -946,7 +1008,7 @@ func (app *App) integrationsUpload(c *gin.Context) {
 	name := common.QueryS("name", c)
 	fileType := common.QueryS("fileType", c)
 
-	integrationProvider, err := integrations.GetIntegrationProvider(app.userStorer, uid, integrationID)
+	integrationProvider, err := integrations.GetStorageIntegrationProvider(app.userStorer, uid, integrationID)
 
 	if err != nil {
 		log.Error(fmt.Errorf("can't get integration, %v", err))
@@ -970,7 +1032,7 @@ func (app *App) integrationsGetFile(c *gin.Context) {
 	integrationID := common.ParamS(integrationKey, c)
 	fileID := common.ParamS(fileKey, c)
 
-	integrationProvider, err := integrations.GetIntegrationProvider(app.userStorer, uid, integrationID)
+	integrationProvider, err := integrations.GetStorageIntegrationProvider(app.userStorer, uid, integrationID)
 	if err != nil {
 		log.Error(err)
 		c.AbortWithStatus(http.StatusInternalServerError)
@@ -999,7 +1061,7 @@ func (app *App) integrationsList(c *gin.Context) {
 		folderDepth, _ = strconv.Atoi(folderDepthStr)
 	}
 
-	integrationProvider, err := integrations.GetIntegrationProvider(app.userStorer, uid, integrationID)
+	integrationProvider, err := integrations.GetStorageIntegrationProvider(app.userStorer, uid, integrationID)
 	if err != nil {
 		log.Error(err)
 		c.AbortWithStatus(http.StatusInternalServerError)

--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -123,6 +123,7 @@ func (app *App) registerRoutes(router *gin.Engine) {
 		authRoutes.GET("/integrations/v2/storage/:"+integrationKey+"/files/:"+fileKey, app.integrationsGetFile)
 		authRoutes.GET("/integrations/v2/storage/:"+integrationKey+"/files/:"+fileKey+"/metadata", app.integrationsGetMetadata)
 		authRoutes.POST("/integrations/v2/storage/:"+integrationKey+"/files/:"+folderKey, app.integrationsUpload)
+		authRoutes.POST("/integrations/v2/messaging/:"+integrationKey+"/message", app.integrationsSendMessage)
 
 		// sync15
 		authRoutes.POST("/api/v1/signed-urls/downloads", app.blobStorageDownload)

--- a/internal/integrations/integrations.go
+++ b/internal/integrations/integrations.go
@@ -14,6 +14,7 @@ import (
 )
 
 const (
+	WebhookProvider = "webhook"
 	SlackProvider   = "slack"
 	FtpProvider     = "ftp"
 	WebdavProvider  = "webdav"
@@ -50,6 +51,8 @@ func getIntegrationProvider(storer storage.UserStorer, uid, integrationid string
 			continue
 		}
 		switch intg.Provider {
+		case WebhookProvider:
+			return newWebhook(intg), nil
 		case DropboxProvider:
 			return newDropbox(intg), nil
 		case FtpProvider:
@@ -95,6 +98,8 @@ func GetMessagingIntegrationProvider(storer storage.UserStorer, uid, integration
 // fix the name
 func fixProviderName(n string) string {
 	switch n {
+	case WebhookProvider:
+		fallthrough
 	case SlackProvider:
 		return "Slack"
 	case FtpProvider:
@@ -112,6 +117,8 @@ func fixProviderName(n string) string {
 
 func ProviderType(n string) string {
 	switch n {
+	case WebhookProvider:
+		fallthrough
 	case SlackProvider:
 		return "Messaging"
 	case FtpProvider:

--- a/internal/integrations/integrations.go
+++ b/internal/integrations/integrations.go
@@ -2,6 +2,7 @@ package integrations
 
 import (
 	"fmt"
+	"image"
 	"io"
 	"io/fs"
 	"path"
@@ -13,6 +14,7 @@ import (
 )
 
 const (
+	SlackProvider   = "slack"
 	FtpProvider     = "ftp"
 	WebdavProvider  = "webdav"
 	DropboxProvider = "dropbox"
@@ -20,16 +22,25 @@ const (
 	LocalfsProvider = "localfs"
 )
 
-// IntegrationProvider abstracts 3rd party integrations
-type IntegrationProvider interface {
+type IntegrationProvider interface{}
+
+// StorageIntegrationProvider abstracts 3rd party integrations
+type StorageIntegrationProvider interface {
+	IntegrationProvider
 	GetMetadata(fileID string) (result *messages.IntegrationMetadata, err error)
 	List(folderID string, depth int) (result *messages.IntegrationFolder, err error)
 	Download(fileID string) (io.ReadCloser, int64, error)
 	Upload(folderID, name, fileType string, reader io.ReadCloser) (string, error)
 }
 
-// GetIntegrationProvider finds the integration provider for the user
-func GetIntegrationProvider(storer storage.UserStorer, uid, integrationid string) (IntegrationProvider, error) {
+// MessagingIntegrationProvider abstracts 3rd party integrations
+type MessagingIntegrationProvider interface {
+	IntegrationProvider
+	SendMessage(data messages.IntegrationMessageData, img image.Image) (string, error)
+}
+
+// getIntegrationProvider finds the integration provider for the user
+func getIntegrationProvider(storer storage.UserStorer, uid, integrationid string) (IntegrationProvider, error) {
 	usr, err := storer.GetUser(uid)
 	if err != nil {
 		return nil, err
@@ -53,9 +64,39 @@ func GetIntegrationProvider(storer storage.UserStorer, uid, integrationid string
 
 }
 
+func GetStorageIntegrationProvider(storer storage.UserStorer, uid, integrationid string) (StorageIntegrationProvider, error) {
+	provider, err := getIntegrationProvider(storer, uid, integrationid)
+	if err != nil {
+		return nil, err
+	}
+
+	sip, ok := provider.(StorageIntegrationProvider)
+	if !ok {
+		return nil, fmt.Errorf("provider %q is not a storage provider", integrationid)
+	}
+
+	return sip, nil
+}
+
+func GetMessagingIntegrationProvider(storer storage.UserStorer, uid, integrationid string) (MessagingIntegrationProvider, error) {
+	provider, err := getIntegrationProvider(storer, uid, integrationid)
+	if err != nil {
+		return nil, err
+	}
+
+	sip, ok := provider.(MessagingIntegrationProvider)
+	if !ok {
+		return nil, fmt.Errorf("provider %q is not a messaging provider", integrationid)
+	}
+
+	return sip, nil
+}
+
 // fix the name
 func fixProviderName(n string) string {
 	switch n {
+	case SlackProvider:
+		return "Slack"
 	case FtpProvider:
 		fallthrough
 	case DropboxProvider:
@@ -64,6 +105,21 @@ func fixProviderName(n string) string {
 		fallthrough
 	case WebdavProvider:
 		return "GoogleDrive"
+	default:
+		return n
+	}
+}
+
+func ProviderType(n string) string {
+	switch n {
+	case SlackProvider:
+		return "Messaging"
+	case FtpProvider:
+		fallthrough
+	case DropboxProvider:
+		fallthrough
+	case WebdavProvider:
+		return "Storage"
 	default:
 		return n
 	}
@@ -82,7 +138,7 @@ func List(userstorer storage.UserStorer, uid string) (*messages.IntegrationsResp
 			ID:           userIntg.ID,
 			Name:         userIntg.Name,
 			Provider:     fixProviderName(userIntg.Provider),
-			ProviderType: "Storage",
+			ProviderType: ProviderType(userIntg.Provider),
 			UserID:       uid,
 		}
 

--- a/internal/integrations/webdav_test.go
+++ b/internal/integrations/webdav_test.go
@@ -52,7 +52,7 @@ func TestUpload(t *testing.T) {
 	t.Log(id)
 }
 
-func GetWebDav() IntegrationProvider {
+func GetWebDav() StorageIntegrationProvider {
 	config := model.IntegrationConfig{
 		Address:  os.Getenv("WEBDAV_ADDRESS"),
 		Username: os.Getenv("WEBDAV_USERNAME"),

--- a/internal/integrations/webhook.go
+++ b/internal/integrations/webhook.go
@@ -1,0 +1,69 @@
+package integrations
+
+import (
+	"bytes"
+	"encoding/json"
+	"image"
+	"image/png"
+	"io"
+	"mime/multipart"
+	"net/http"
+
+	"github.com/ddvk/rmfakecloud/internal/messages"
+	"github.com/ddvk/rmfakecloud/internal/model"
+)
+
+type Webhook struct {
+	Endpoint string
+}
+
+func newWebhook(i model.IntegrationConfig) *Webhook {
+	return &Webhook{
+		Endpoint: i.Endpoint,
+	}
+}
+
+func (i *Webhook) SendMessage(data messages.IntegrationMessageData, img image.Image) (string, error) {
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	// Add data field
+	if mdata, err := json.Marshal(data); err != nil {
+		return "", err
+	} else if err := writer.WriteField("data", string(mdata)); err != nil {
+		return "", err
+	}
+
+	// Add attachment
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		return "", err
+	}
+
+	part, err := writer.CreateFormFile("attachment", "reMarkable.png")
+	if err != nil {
+		return "", err
+	}
+	if _, err := part.Write(buf.Bytes()); err != nil {
+		return "", err
+	}
+
+	// Close
+	if err := writer.Close(); err != nil {
+		return "", err
+	}
+
+	// Do the request
+	resp, err := http.Post(i.Endpoint, writer.FormDataContentType(), body)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	responseData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(responseData), nil
+}

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -1,6 +1,7 @@
 package messages
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/ddvk/rmfakecloud/internal/common"
@@ -115,8 +116,8 @@ type UploadResponse struct {
 // EndpointReponse endpoint hosts
 type EndpointsResponse struct {
 	Notifications string `json:"notifications"`
-	Webapp string `json:"webapp"`
-	MQTT string `json:"mqttbroker,omitempty"`
+	Webapp        string `json:"webapp"`
+	MQTT          string `json:"mqttbroker,omitempty"`
 }
 
 // HostResponse what the host responded
@@ -233,4 +234,8 @@ type IntegrationMetadata struct {
 	SourceFileType   string `json:"sourceFileType"`
 	ProvidedFileType string `json:"providedFileType"`
 	FileType         string `json:"fileType"`
+}
+
+type IntegrationMessageData struct {
+	Destinations []json.RawMessage `json:"destinations"`
 }

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -80,6 +80,9 @@ type IntegrationConfig struct {
 	// Localfs
 	// really dangerous as it allows path traversal
 	Path string `yaml:"path,omitempty"`
+
+	// Webhook
+	Endpoint string `yaml:"endpoint,omitempty"`
 }
 
 // GenPassword generates a new random password

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -689,7 +689,7 @@ func (app *ReactAppWrapper) exploreIntegration(c *gin.Context) {
 
 	integrationID := common.ParamS(intIDParam, c)
 
-	integrationProvider, err := integrations.GetIntegrationProvider(app.userStorer, uid, integrationID)
+	integrationProvider, err := integrations.GetStorageIntegrationProvider(app.userStorer, uid, integrationID)
 	if err != nil {
 		log.Error(err)
 		c.AbortWithStatus(http.StatusInternalServerError)
@@ -716,7 +716,7 @@ func (app *ReactAppWrapper) getMetadataIntegration(c *gin.Context) {
 
 	integrationID := common.ParamS(intIDParam, c)
 
-	integrationProvider, err := integrations.GetIntegrationProvider(app.userStorer, uid, integrationID)
+	integrationProvider, err := integrations.GetStorageIntegrationProvider(app.userStorer, uid, integrationID)
 	if err != nil {
 		log.Error(err)
 		c.AbortWithStatus(http.StatusInternalServerError)
@@ -740,7 +740,7 @@ func (app *ReactAppWrapper) downloadThroughIntegration(c *gin.Context) {
 
 	integrationID := common.ParamS(intIDParam, c)
 
-	integrationProvider, err := integrations.GetIntegrationProvider(app.userStorer, uid, integrationID)
+	integrationProvider, err := integrations.GetStorageIntegrationProvider(app.userStorer, uid, integrationID)
 	if err != nil {
 		log.Error(err)
 		c.AbortWithStatus(http.StatusInternalServerError)

--- a/ui/src/pages/Integrations/IntegrationModal.jsx
+++ b/ui/src/pages/Integrations/IntegrationModal.jsx
@@ -20,6 +20,7 @@ export default function IntegrationModal(params) {
     insecure: integration?.Insecure,
     accesstoken: integration?.Accesstoken,
     path: integration?.Path,
+    endpoint: integration?.Endpoint,
   });
 
   function handleChange({ target }) {
@@ -53,6 +54,7 @@ export default function IntegrationModal(params) {
         insecure: integrationForm.insecure,
         accesstoken: integrationForm.accesstoken,
         path: integrationForm.path,
+        endpoint: integrationForm.endpoint,
       });
       onSave();
     } catch (e) {
@@ -95,6 +97,7 @@ export default function IntegrationModal(params) {
               <option value="webdav">WebDAV</option>
               <option value="ftp">FTP</option>
               <option value="dropbox">Dropbox</option>
+              <option value="webhook">Messaging webhook</option>
             </Form.Control>
 
             <Form.Label>Name</Form.Label>
@@ -168,6 +171,18 @@ export default function IntegrationModal(params) {
                   placeholder="Access Token"
                   value={integrationForm.accesstoken}
                   name="accesstoken"
+                  onChange={handleChange}
+                />
+              </>
+            )}
+
+            {integrationForm.provider === "webhook" && (
+              <>
+                <Form.Label>Endpoint</Form.Label>
+                <Form.Control
+                  placeholder="https://automation.domain.tld/webhook/0123-456789-abc"
+                  value={integrationForm.endpoint}
+                  name="endpoint"
                   onChange={handleChange}
                 />
               </>

--- a/ui/src/pages/Integrations/NewIntegrationModal.jsx
+++ b/ui/src/pages/Integrations/NewIntegrationModal.jsx
@@ -36,6 +36,7 @@ export default function IntegrationProfileModal(params) {
 
     if (!formIsValid()) return;
 
+    console.log(integrationForm)
     try {
       await apiService.createintegration(integrationForm);
       setFormInfo({ message: "Created" });
@@ -83,6 +84,7 @@ export default function IntegrationProfileModal(params) {
             <option value="ftp">FTP</option>
             <option value="webdav">WebDAV</option>
             <option value="dropbox">Dropbox</option>
+            <option value="webhook">Messaging webhook</option>
           </Form.Select>
 
           {(integrationForm.provider === "webdav" || integrationForm.provider === "ftp") && (
@@ -148,6 +150,18 @@ export default function IntegrationProfileModal(params) {
                 placeholder="Access Token"
                 value={integrationForm.accesstoken}
                 name="accesstoken"
+                onChange={handleChange}
+              />
+            </>
+          )}
+
+          {integrationForm.provider === "webhook" && (
+            <>
+              <Form.Label>Endpoint</Form.Label>
+              <Form.Control
+                placeholder="https://automation.domain.tld/webhook/0123-456789-abc"
+                value={integrationForm.endpoint}
+                name="endpoint"
                 onChange={handleChange}
               />
             </>


### PR DESCRIPTION
The new 3.20 release introduces a new attribute in JWT.

I don't have the release on my reMarkable yet to test this change and to ensure this is the only change requires to fix #363.

Most probably the host `eu.tectonic.remarkable.com` needs to be added to `/etc/hosts` in [rmfakecloud-proxy](https://github.com/ddvk/rmfakecloud-proxy/blob/master/scripts/installer.sh#L167)