### PR TITLE
Implement (multi-select) delete with confirmation

### DIFF
--- a/ui/src/App.scss
+++ b/ui/src/App.scss
@@ -231,6 +231,15 @@ div[role="tree"] {
     white-space: nowrap;
     text-overflow: ellipsis;
   }
+
+  .filelist-checkbox {
+    position: absolute;
+    margin: 0.4em;
+  }
+
+  .filegrid-checkbox-spacer {
+    margin-left: 2.4em;
+  }
 }
 
 main h2 {

--- a/ui/src/App.scss
+++ b/ui/src/App.scss
@@ -178,6 +178,10 @@ div[role="tree"] {
       font-size: 0.8em;
       padding:  0 0.5em;
     }
+
+    .filelist-checkbox {
+      margin-right: 0.8em;
+    }
   }
 }
 

--- a/ui/src/pages/Documents/FileList.jsx
+++ b/ui/src/pages/Documents/FileList.jsx
@@ -13,7 +13,7 @@ function formatBytes(bytes) {
   return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
 }
 
-export default function FileListViewer({ listStyle, files, onSelect, counter }) {
+export default function FileListViewer({ listStyle, files, onSelect, counter, selectedIds = [], onSelectItem }) {
   const onClickItem = (file) => {
     onSelect(file);
   }
@@ -26,6 +26,15 @@ export default function FileListViewer({ listStyle, files, onSelect, counter }) 
   const listItems = files.map(file =>
     <div className="filelist-item p-2" key={file.id} onClick={() => onClickItem(file)}>
       <Stack direction="horizontal">
+        <div>
+          <input
+            type="checkbox"
+            checked={selectedIds.includes(file.id)}
+            onClick={e => e.stopPropagation()}
+            onChange={() => onSelectItem && onSelectItem(file.id)}
+            className="filelist-checkbox"
+          />
+        </div>
         <div>
           <FileIcon file={file.data} />
         </div>

--- a/ui/src/pages/Documents/FileList.jsx
+++ b/ui/src/pages/Documents/FileList.jsx
@@ -56,8 +56,15 @@ export default function FileListViewer({ listStyle, files, onSelect, counter, se
   );
 
   const gridFolderItems = files.filter(file => !file.isLeaf).map(file =>
-    <div className="filegrid-folder-item" key={file.id} onClick={() => onClickItem(file)}>
-      <div>
+    <div className="filegrid-folder-item" key={file.id}>
+      <input
+        type="checkbox"
+        checked={selectedIds.includes(file.id)}
+        onClick={e => e.stopPropagation()}
+        onChange={() => onSelectItem && onSelectItem(file.id)}
+        className="filelist-checkbox"
+      />
+      <div className="filegrid-checkbox-spacer" onClick={() => onClickItem(file)}>
         <FileIcon file={file.data} />
         {file.data.name}
       </div>
@@ -65,8 +72,15 @@ export default function FileListViewer({ listStyle, files, onSelect, counter, se
   );
 
   const gridFileItems = files.filter(file => file.isLeaf).map(file =>
-    <div className="filegrid-file-item" key={file.id} onClick={() => onClickItem(file)}>
-      <div className="fileicon">
+    <div className="filegrid-file-item" key={file.id}>
+      <input
+        type="checkbox"
+        checked={selectedIds.includes(file.id)}
+        onClick={e => e.stopPropagation()}
+        onChange={() => onSelectItem && onSelectItem(file.id)}
+        className="filelist-checkbox"
+      />
+      <div className="filegrid-checkbox-spacer fileicon" onClick={() => onClickItem(file)}>
         <FileIcon file={file.data} />
       </div>
       <div className="filename">

--- a/ui/src/pages/Documents/Folder.jsx
+++ b/ui/src/pages/Documents/Folder.jsx
@@ -27,7 +27,7 @@ export default function Folder({ selection, onSelect, onUpdate }) {
     console.log("created folder with id", res.ID);
     setFolderName("");
     setShowCreateFolder(false);
-    
+
     onUpdate();
   }
 

--- a/ui/src/services/api.service.js
+++ b/ui/src/services/api.service.js
@@ -88,6 +88,13 @@ class ApiServices {
       return r.json();
     });
   }
+
+  deleteDocument(id) {
+    return fetch(`${constants.ROOT_URL}/documents/${id}`, {
+      method: "DELETE",
+      headers: this.header(),
+    }).then((r) => handleError(r));
+  }
   download(id) {
     return fetch(`${constants.ROOT_URL}/documents/${id}`, {
       method: "GET",
@@ -97,6 +104,7 @@ class ApiServices {
       return r.blob();
     });
   }
+
   createFolder(data) {
     return fetch(`${constants.ROOT_URL}/folders`, {
       method: "POST",


### PR DESCRIPTION
This PR adds the ability to select multiple files and folders in the Documents list view and delete them in a single action.

### Screenshots:
<img width="1086" height="543" alt="image" src="https://github.com/user-attachments/assets/b683d487-d731-4d23-9256-b585e2beeac5" />
<img width="1086" height="543" alt="image" src="https://github.com/user-attachments/assets/7f288349-acde-4dc3-a020-d25a2ee0b126" />
<img width="1086" height="647" alt="image" src="https://github.com/user-attachments/assets/befd0c4d-8f43-42b9-9392-bcb8aa8f573f" />
<img width="1119" height="323" alt="image" src="https://github.com/user-attachments/assets/46f57879-fbad-44b4-ab55-4fbb48caa354" />

### Features:
- Adds checkboxes to each file/folder in the list view for multi-selection
- Enables the Delete button only when at least one item is selected
- Shows a confirmation dialog before deletion
- Displays a toast notification with the name of each deleted item or folder

### How to test:
- Go to the Documents page, select either grid-view or list-item
- Select one or more files/folders using the checkboxes
- Click the Delete button
- Confirm the deletion in the dialog
- Verify that the selected items are deleted, a toast appears for each (in this PR without [375](https://github.com/ddvk/rmfakecloud/pull/375) requires a manual refresh, existing behavior)

### Other notes:
- The delete logic is implemented in Folder.jsx
- The UI/UX is consistent with the rest of the application
- No breaking changes to existing functionality
- The fix to auto refresh the item list (so you do not have to refresh uploading or deleting files or creating folders) will be in a separate PR; [here](https://github.com/ddvk/rmfakecloud/pull/375)