### PR TITLE
Auto-refresh filetree after changes

### DIFF
--- a/ui/src/App.scss
+++ b/ui/src/App.scss
@@ -234,3 +234,7 @@ main h2 {
 }
 
 @import "bootstrap/scss/bootstrap";
+
+.flex-spacer {
+  flex: 1;
+}

--- a/ui/src/pages/Documents/FileList.jsx
+++ b/ui/src/pages/Documents/FileList.jsx
@@ -32,8 +32,7 @@ export default function FileListViewer({ listStyle, files, onSelect, counter }) 
         <div className={isFolderClassName(file)}>
           {file.data.name}
         </div>
-        <div style={{ flex: 1 }}>
-        </div>
+        <div className="flex-spacer"></div>
         <div className="filelist-metadata">
           {!file.isLeaf && <span>{file.children.length || "empty"}</span> }
           {file.isLeaf && <span>{formatBytes(file.data.size)}</span> }

--- a/ui/src/pages/Documents/index.jsx
+++ b/ui/src/pages/Documents/index.jsx
@@ -20,10 +20,25 @@ export default function DocumentList() {
   const [showSearch, setShowSearch] = useState(false);
   const [counter, setCounter] = useState(0);
   const [entries, setEntries] = useState([])
+  const [initialSelectionSet, setInitialSelectionSet] = useState(false);
 
   const { state: { user } } = useAuthState();
 
   const treeRef = useRef(null);
+  const lastSelectedId = useRef(null);
+
+  useEffect(() => {
+    lastSelectedId.current = selected?.id || null;
+  }, [selected]);
+
+  useEffect(() => {
+    if (lastSelectedId.current && treeRef.current && typeof treeRef.current.get === 'function') {
+      const node = treeRef.current.get(lastSelectedId.current);
+      if (node && node !== selected) {
+        setSelected(node);
+      }
+    }
+  }, [entries]);
 
   const toggleNode = (node) => {
     if (node == null) {
@@ -51,12 +66,18 @@ export default function DocumentList() {
     setCounter(prev => prev+1);
   };
 
-  if (!selected) {
-    const tree = treeRef.current
-    if (tree) {
-      setSelected(tree.root.children[0])
+  useEffect(() => {
+    if (
+      !initialSelectionSet &&
+      selected === null &&
+      treeRef.current &&
+      treeRef.current.root &&
+      treeRef.current.root.children[0]
+    ) {
+      setSelected(treeRef.current.root.children[0]);
+      setInitialSelectionSet(true);
     }
-  }
+  }, [entries, selected, initialSelectionSet]);
 
 	useEffect(() => {
 		const loadDocs = async () => {


### PR DESCRIPTION
This PR adds the functionality of the filetree being updated after folder or file changes, to avoid having to refresh to page manually for this.

### Auto-refresh filetree after changes:
- Ensures the file/folder tree view automatically refreshes and updates its contents after actions such as file/folder creation, upload, or deletion, without requiring a manual page reload

### Boyscout for flex spacer:
- Replaces the inline style={{ flex: 1 }} spacer in the file/folder list with a .flex-spacer SCSS class

### How to test:
- Flex spacer refactor:
  - Open the Documents list view
  - Verify that the file/folder name remains left-aligned and the metadata (size, date, etc.) remains right-aligned, with no layout regressions
- Filetree auto-update:
  - Create a new folder or upload a file in any directory
  - Delete one or more files/folders
  - Confirm that the file/folder list updates immediately after each action, reflecting the changes without needing to refresh the page

### Other notes:
- No breaking changes to existing functionality