### PR TITLE
fix: add /pair and /pair/app paths to connect

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -44,6 +44,8 @@ export default function App() {
                 <PrivateRoute exact path="/" component={Home} />
                 <PrivateRoute path="/documents/:itemId?" component={Documents} />
                 <PrivateRoute path="/connect" component={Connect} />
+                <PrivateRoute path="/pair/app" component={Connect} />
+                <PrivateRoute path="/pair" component={Connect} />
                 <PrivateRoute path="/integrations" component={Integrations} />
                 <PrivateRoute path="/profile" component={Profile} />
                 <PrivateRoute path="/admin" roles={[Role.Admin]} component={Admin} />


### PR DESCRIPTION
This adds /pair and /pair/app paths to the connect page so that when the apps pop open a browser for code retrevial rmfakecloud doesn't 404