### PR TITLE
feat: calendar integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ See the [documentation](https://ddvk.github.io/rmfakecloud/remarkable/setup/) fo
 | Integration with FTP | ✅ |  |
 | Messaging integrations | ✅ |  |
 | [Messaging integration through webhook](https://ddvk.github.io/rmfakecloud/usage/integrations/#messaging-webhook) | ✅ |  |
+| Calendar integration | ✅ | ICS currently supported
 | Messaging integration to Slack | 🟡 | Not directly, use a webhook with zapier/make/n8n |
 | Archive document to cloud | 🟡 | It works but the information is not saved |
 | Document rendering in web interface | ❌ | [WIP](https://github.com/ddvk/rmfakecloud/issues/255) |

--- a/cmd/rmfakecloud/main.go
+++ b/cmd/rmfakecloud/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	_ "time/tzdata"
 
 	"github.com/ddvk/rmfakecloud/internal/app"
 	"github.com/ddvk/rmfakecloud/internal/cli"

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.3
 toolchain go1.24.1
 
 require (
+	github.com/apognu/gocal v0.9.1
 	github.com/danjacques/gofslock v0.0.0-20240212154529-d899e02bfe22
 	github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.0.5
 	github.com/gin-gonic/gin v1.9.1
@@ -17,7 +18,6 @@ require (
 	github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5
 	github.com/secsy/goftp v0.0.0-20200609142545-aa2de14babf4
 	github.com/sirupsen/logrus v1.9.3
-	github.com/soheilhy/cmux v0.1.5
 	github.com/stretchr/testify v1.9.0
 	github.com/studio-b12/gowebdav v0.9.0
 	github.com/unidoc/unipdf/v3 v3.56.0
@@ -26,6 +26,7 @@ require (
 )
 
 require (
+	github.com/ChannelMeter/iso8601duration v0.0.0-20150204201828-8da3af7a2a61 // indirect
 	github.com/adrg/strutil v0.3.1 // indirect
 	github.com/adrg/sysfont v0.1.2 // indirect
 	github.com/adrg/xdg v0.4.0 // indirect
@@ -40,6 +41,7 @@ require (
 	github.com/go-playground/validator/v10 v10.19.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/gorilla/i18n v0.0.0-20150820051429-8b358169da46 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/jung-kurt/gofpdf v1.16.2 // indirect
@@ -49,6 +51,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pelletier/go-toml/v2 v2.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/xid v1.4.0 // indirect
@@ -68,4 +71,5 @@ require (
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/ChannelMeter/iso8601duration v0.0.0-20150204201828-8da3af7a2a61 h1:N5Vqww5QISEHsWHOWDEx4PzdIay3Cg0Jp7zItq2ZAro=
+github.com/ChannelMeter/iso8601duration v0.0.0-20150204201828-8da3af7a2a61/go.mod h1:GnKXcK+7DYNy/8w2Ex//Uql4IgfaU82Cd5rWKb7ah00=
 github.com/adrg/strutil v0.2.2/go.mod h1:EF2fjOFlGTepljfI+FzgTG13oXthR7ZAil9/aginnNQ=
 github.com/adrg/strutil v0.3.1 h1:OLvSS7CSJO8lBii4YmBt8jiK9QOtB9CzCzwl4Ic/Fz4=
 github.com/adrg/strutil v0.3.1/go.mod h1:8h90y18QLrs11IBffcGX3NW/GFBXCMcNg4M7H6MspPA=
@@ -41,12 +43,16 @@ github.com/adrg/sysfont v0.1.2/go.mod h1:6d3l7/BSjX9VaeXWJt9fcrftFaD/t7l11xgSywC
 github.com/adrg/xdg v0.3.0/go.mod h1:7I2hH/IT30IsupOpKZ5ue7/qNi3CoKzD6tL3HwpaRMQ=
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
 github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
+github.com/apognu/gocal v0.9.1 h1:e3vlb+YV5wXvqBxYsC6GvkuUAEnRipkvoA1P79gwspM=
+github.com/apognu/gocal v0.9.1/go.mod h1:5tNvJsQGJHwS3KqWxHAFZzavC4k42jrJ3ouVmOzS/AM=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
 github.com/bytedance/sonic v1.10.0-rc/go.mod h1:ElCzW+ufi8qKqNW0FY314xriJhyJhuoJ3gFZdAHF7NM=
 github.com/bytedance/sonic v1.11.3 h1:jRN+yEjakWh8aK5FzrciUHG8OFXK+4/KrAX/ysEtHAA=
 github.com/bytedance/sonic v1.11.3/go.mod h1:iZcSUejdk5aukTND/Eu/ivjQuEL0Cu9/rf50Hi0u/g4=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/channelmeter/iso8601duration v0.0.0-20150204201828-8da3af7a2a61 h1:o64h9XF42kVEUuhuer2ehqrlX8rZmvQSU0+Vpj1rF6Q=
+github.com/channelmeter/iso8601duration v0.0.0-20150204201828-8da3af7a2a61/go.mod h1:Rp8e0DCtEKwXFOC6JPJQVTz8tuGoGvw6Xfexggh/ed0=
 github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06/go.mod h1:DH46F32mSOjUmXrMHnKwZdA8wcEefY7UVqBKYGjpdQY=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311/go.mod h1:b583jCggY9gE99b6G5LEC39OIiVsWj+R97kbl5odCEk=
 github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d h1:77cEq6EriyTZ0g/qfRdp61a3Uu/AWrgIq2s0ClJV1g0=
@@ -129,8 +135,8 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -172,8 +178,6 @@ github.com/knz/go-libedit v1.10.1/go.mod h1:MZTVkCWyz0oBc7JOWP3wNAzd002ZbM/5hgSh
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
-github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -191,6 +195,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pelletier/go-toml/v2 v2.2.0 h1:QLgLl2yMN7N+ruc31VynXs1vhMZa7CeHHejIeBAsoHo=
 github.com/pelletier/go-toml/v2 v2.2.0/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
 github.com/phpdave11/gofpdi v1.0.7/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
@@ -203,8 +209,6 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5 h1:mZHayPoR0lNmnHyvtYjDeq0zlVHn9K/ZXoy17ylucdo=
 github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5/go.mod h1:GEXHk5HgEKCvEIIrSpFI3ozzG5xOKA2DVlEX/gGnewM=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
-github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rs/xid v1.4.0 h1:qd7wPTDkN6KQx2VmMBLrpHkiyQwgFXRnkOLacUiaSNY=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
@@ -213,8 +217,6 @@ github.com/secsy/goftp v0.0.0-20200609142545-aa2de14babf4/go.mod h1:MnkX001NG75g
 github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s+Squfpo=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
-github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -333,7 +335,6 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
@@ -539,8 +540,8 @@ google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGm
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -12,6 +12,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/mail"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -1000,6 +1001,28 @@ func (app *App) integrationsSendMessage(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"id": id})
 }
 
+func (app *App) integrationsCalendarEvents(c *gin.Context) {
+	uid := userID(c)
+	integrationID := common.ParamS(integrationKey, c)
+
+	provider, err := integrations.GetCalendarIntegrationProvider(app.userStorer, uid, integrationID)
+	if err != nil {
+		log.Error(fmt.Errorf("can't get calendar integration, %v", err))
+		c.AbortWithStatus(http.StatusInternalServerError)
+		return
+	}
+
+	now := time.Now().UTC()
+	response, err := provider.ListEvents(now, now.Add(24*time.Hour))
+	if err != nil {
+		log.Error(err)
+		c.AbortWithStatus(http.StatusInternalServerError)
+		return
+	}
+
+	c.JSON(http.StatusOK, response)
+}
+
 func (app *App) integrationsUpload(c *gin.Context) {
 	log.Info("uploading...")
 	uid := userID(c)
@@ -1088,8 +1111,32 @@ func (app *App) integrations(c *gin.Context) {
 		c.AbortWithStatus(http.StatusUnauthorized)
 		return
 	}
+
+	if !supportsCalendarIntegration(c.GetHeader("User-Agent")) {
+		filtered := &messages.IntegrationsResponse{}
+		for _, intg := range response.Integrations {
+			if intg.ProviderType != "Calendar" {
+				filtered.Integrations = append(filtered.Integrations, intg)
+			}
+		}
+		response = filtered
+	}
+
 	c.JSON(http.StatusOK, response)
 }
+
+var xochitlVersionRe = regexp.MustCompile(`xochitl/(\d+)\.(\d+)`)
+
+func supportsCalendarIntegration(ua string) bool {
+	m := xochitlVersionRe.FindStringSubmatch(ua)
+	if m == nil {
+		return true
+	}
+	major, _ := strconv.Atoi(m[1])
+	minor, _ := strconv.Atoi(m[2])
+	return major > 3 || (major == 3 && minor >= 27)
+}
+
 func (app *App) uploadRequest(c *gin.Context) {
 	uid := userID(c)
 	var req []messages.UploadRequest

--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -127,6 +127,7 @@ func (app *App) registerRoutes(router *gin.Engine) {
 		authRoutes.GET("/integrations/v2/storage/:"+integrationKey+"/files/:"+fileKey+"/metadata", app.integrationsGetMetadata)
 		authRoutes.POST("/integrations/v2/storage/:"+integrationKey+"/files/:"+folderKey, app.integrationsUpload)
 		authRoutes.POST("/integrations/v2/messaging/:"+integrationKey+"/message", app.integrationsSendMessage)
+		authRoutes.GET("/integrations/v2/calendars/:"+integrationKey+"/events", app.integrationsCalendarEvents)
 
 		// sync15
 		authRoutes.POST("/api/v1/signed-urls/downloads", app.blobStorageDownload)

--- a/internal/integrations/ics.go
+++ b/internal/integrations/ics.go
@@ -1,0 +1,295 @@
+package integrations
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/apognu/gocal"
+	"github.com/ddvk/rmfakecloud/internal/messages"
+	"github.com/ddvk/rmfakecloud/internal/model"
+	"github.com/sirupsen/logrus"
+)
+
+func init() {
+	gocal.SetTZMapper(func(s string) (*time.Location, error) {
+		return loadTimezone(s), nil
+	})
+}
+
+var icsCacheMap sync.Map
+
+type cachedICS struct {
+	mu        sync.Mutex
+	data      []byte
+	fetchedAt time.Time
+}
+
+type icsIntegration struct {
+	url      string
+	insecure bool
+}
+
+func newICS(cfg model.IntegrationConfig) *icsIntegration {
+	return &icsIntegration{
+		url:      cfg.Address,
+		insecure: cfg.Insecure,
+	}
+}
+
+func (i *icsIntegration) ListEvents(windowStart, windowEnd time.Time) (*messages.CalendarEventsResponse, error) {
+	logrus.Infof("[ics] fetching events from %s, window %s to %s", i.url, windowStart.Format(time.RFC3339), windowEnd.Format(time.RFC3339))
+
+	data, err := i.fetch()
+	if err != nil {
+		return nil, err
+	}
+
+	c := gocal.NewParser(bytes.NewReader(data))
+	c.Start = &windowStart
+	c.End = &windowEnd
+	c.Strict.Mode = gocal.StrictModeFailEvent
+
+	if err := c.Parse(); err != nil {
+		return nil, fmt.Errorf("parsing ICS: %w", err)
+	}
+
+	logrus.Infof("[ics] parsed %d events in window", len(c.Events))
+
+	var events []messages.CalendarEvent
+	for _, e := range c.Events {
+		evt := convertEvent(e)
+		logrus.Infof("[ics] -> %q start=%s end=%s (utc: %s - %s)", evt.Title, evt.StartTime, evt.EndTime, evt.StartTimeUtc, evt.EndTimeUtc)
+		events = append(events, evt)
+	}
+
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].StartTimeUtc < events[j].StartTimeUtc
+	})
+
+	logrus.Infof("[ics] returning %d events", len(events))
+	return &messages.CalendarEventsResponse{
+		RetrievedAtUtc: time.Now().UTC().Format("2006-01-02T15:04:05.999999999Z"),
+		Events:         events,
+	}, nil
+}
+
+const icsCacheTTL = 5 * time.Minute
+
+func (i *icsIntegration) fetch() ([]byte, error) {
+	val, _ := icsCacheMap.LoadOrStore(i.url, &cachedICS{})
+	cached := val.(*cachedICS)
+
+	cached.mu.Lock()
+	defer cached.mu.Unlock()
+
+	if cached.data != nil && time.Since(cached.fetchedAt) < icsCacheTTL {
+		logrus.Debug("[ics] using cached ICS data")
+		return cached.data, nil
+	}
+
+	logrus.Infof("[ics] fetching ICS from %s", i.url)
+	client := &http.Client{Timeout: 30 * time.Second}
+	if i.insecure {
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+	}
+
+	resp, err := client.Get(i.url)
+	if err != nil {
+		return nil, fmt.Errorf("fetching ICS: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetching ICS: status %d", resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading ICS: %w", err)
+	}
+
+	cached.data = data
+	cached.fetchedAt = time.Now()
+
+	logrus.Infof("[ics] fetched %d bytes", len(data))
+	return data, nil
+}
+
+func convertEvent(e gocal.Event) messages.CalendarEvent {
+	eventID := e.Uid
+	if e.IsRecurring && e.Start != nil {
+		eventID = fmt.Sprintf("%s_%s", e.Uid, e.Start.UTC().Format("20060102T150405Z"))
+	}
+
+	var lastMod string
+	if e.LastModified != nil {
+		lastMod = e.LastModified.UTC().Format("2006-01-02T15:04:05Z")
+	} else if e.Stamp != nil {
+		lastMod = e.Stamp.UTC().Format("2006-01-02T15:04:05Z")
+	} else {
+		lastMod = time.Now().UTC().Format("2006-01-02T15:04:05Z")
+	}
+
+	var startUtc, endUtc, startLocal, endLocal string
+	if e.Start != nil {
+		startUtc = e.Start.UTC().Format("2006-01-02T15:04:05Z")
+		startLocal = e.Start.Format("2006-01-02T15:04:05-07:00")
+	}
+	if e.End != nil {
+		endUtc = e.End.UTC().Format("2006-01-02T15:04:05Z")
+		endLocal = e.End.Format("2006-01-02T15:04:05-07:00")
+	}
+
+	var organizer *messages.CalendarPerson
+	if e.Organizer != nil {
+		email := strings.TrimPrefix(strings.ToLower(e.Organizer.Value), "mailto:")
+		name := e.Organizer.Cn
+		if name == "" {
+			name = email
+		}
+		organizer = &messages.CalendarPerson{Name: name, Email: email}
+	}
+
+	var attendees []messages.CalendarPerson
+	for _, a := range e.Attendees {
+		email := strings.TrimPrefix(strings.ToLower(a.Value), "mailto:")
+		name := a.Cn
+		if name == "" {
+			name = email
+		}
+		attendees = append(attendees, messages.CalendarPerson{Name: name, Email: email})
+	}
+
+	responseStatus := "accepted"
+	for _, a := range e.Attendees {
+		switch strings.ToUpper(a.Status) {
+		case "ACCEPTED":
+			responseStatus = "accepted"
+		case "DECLINED":
+			responseStatus = "declined"
+		case "TENTATIVE":
+			responseStatus = "tentative"
+		}
+	}
+
+	return messages.CalendarEvent{
+		ID:                  eventID,
+		Title:               e.Summary,
+		StartTimeUtc:        startUtc,
+		EndTimeUtc:          endUtc,
+		LastModifiedTimeUtc: lastMod,
+		StartTime:           startLocal,
+		EndTime:             endLocal,
+		ResponseStatus:      responseStatus,
+		Organizer:           organizer,
+		Attendees:           attendees,
+	}
+}
+
+var windowsTimezones = map[string]string{
+	"AUS Central Standard Time":       "Australia/Darwin",
+	"AUS Eastern Standard Time":       "Australia/Sydney",
+	"Afghanistan Standard Time":       "Asia/Kabul",
+	"Alaskan Standard Time":           "America/Anchorage",
+	"Arab Standard Time":              "Asia/Riyadh",
+	"Arabian Standard Time":           "Asia/Dubai",
+	"Arabic Standard Time":            "Asia/Baghdad",
+	"Argentina Standard Time":         "America/Argentina/Buenos_Aires",
+	"Atlantic Standard Time":          "America/Halifax",
+	"Azerbaijan Standard Time":        "Asia/Baku",
+	"Azores Standard Time":            "Atlantic/Azores",
+	"Canada Central Standard Time":    "America/Regina",
+	"Cape Verde Standard Time":        "Atlantic/Cape_Verde",
+	"Central America Standard Time":   "America/Guatemala",
+	"Central Asia Standard Time":      "Asia/Almaty",
+	"Central Brazilian Standard Time": "America/Cuiaba",
+	"Central Europe Standard Time":    "Europe/Budapest",
+	"Central European Standard Time":  "Europe/Warsaw",
+	"Central Pacific Standard Time":   "Pacific/Guadalcanal",
+	"Central Standard Time":           "America/Chicago",
+	"Central Standard Time (Mexico)":  "America/Mexico_City",
+	"China Standard Time":             "Asia/Shanghai",
+	"E. Africa Standard Time":         "Africa/Nairobi",
+	"E. Australia Standard Time":      "Australia/Brisbane",
+	"E. Europe Standard Time":         "Europe/Chisinau",
+	"E. South America Standard Time":  "America/Sao_Paulo",
+	"Eastern Standard Time":           "America/New_York",
+	"Egypt Standard Time":             "Africa/Cairo",
+	"FLE Standard Time":               "Europe/Kiev",
+	"GMT Standard Time":               "Europe/London",
+	"GTB Standard Time":               "Europe/Bucharest",
+	"Georgian Standard Time":          "Asia/Tbilisi",
+	"Greenland Standard Time":         "America/Godthab",
+	"Greenwich Standard Time":         "Atlantic/Reykjavik",
+	"Hawaiian Standard Time":          "Pacific/Honolulu",
+	"India Standard Time":             "Asia/Calcutta",
+	"Iran Standard Time":              "Asia/Tehran",
+	"Israel Standard Time":            "Asia/Jerusalem",
+	"Jordan Standard Time":            "Asia/Amman",
+	"Korea Standard Time":             "Asia/Seoul",
+	"Mauritius Standard Time":         "Indian/Mauritius",
+	"Middle East Standard Time":       "Asia/Beirut",
+	"Mountain Standard Time":          "America/Denver",
+	"Mountain Standard Time (Mexico)": "America/Chihuahua",
+	"Myanmar Standard Time":           "Asia/Rangoon",
+	"N. Central Asia Standard Time":   "Asia/Novosibirsk",
+	"Namibia Standard Time":           "Africa/Windhoek",
+	"Nepal Standard Time":             "Asia/Katmandu",
+	"New Zealand Standard Time":       "Pacific/Auckland",
+	"Newfoundland Standard Time":      "America/St_Johns",
+	"North Asia East Standard Time":   "Asia/Irkutsk",
+	"North Asia Standard Time":        "Asia/Krasnoyarsk",
+	"Pacific SA Standard Time":        "America/Santiago",
+	"Pacific Standard Time":           "America/Los_Angeles",
+	"Pacific Standard Time (Mexico)":  "America/Tijuana",
+	"Pakistan Standard Time":          "Asia/Karachi",
+	"Romance Standard Time":           "Europe/Paris",
+	"Russia Time Zone 3":              "Europe/Samara",
+	"Russian Standard Time":           "Europe/Moscow",
+	"SA Eastern Standard Time":        "America/Cayenne",
+	"SA Pacific Standard Time":        "America/Bogota",
+	"SA Western Standard Time":        "America/La_Paz",
+	"SE Asia Standard Time":           "Asia/Bangkok",
+	"Singapore Standard Time":         "Asia/Singapore",
+	"South Africa Standard Time":      "Africa/Johannesburg",
+	"Sri Lanka Standard Time":         "Asia/Colombo",
+	"Taipei Standard Time":            "Asia/Taipei",
+	"Tasmania Standard Time":          "Australia/Hobart",
+	"Tokyo Standard Time":             "Asia/Tokyo",
+	"Turkey Standard Time":            "Europe/Istanbul",
+	"US Eastern Standard Time":        "America/Indianapolis",
+	"US Mountain Standard Time":       "America/Phoenix",
+	"UTC":                             "UTC",
+	"Venezuela Standard Time":         "America/Caracas",
+	"W. Australia Standard Time":      "Australia/Perth",
+	"W. Central Africa Standard Time": "Africa/Lagos",
+	"W. Europe Standard Time":         "Europe/Berlin",
+	"West Asia Standard Time":         "Asia/Tashkent",
+	"West Pacific Standard Time":      "Pacific/Port_Moresby",
+	"Yakutsk Standard Time":           "Asia/Yakutsk",
+}
+
+func loadTimezone(tzid string) *time.Location {
+	if loc, err := time.LoadLocation(tzid); err == nil {
+		return loc
+	}
+
+	if iana, ok := windowsTimezones[tzid]; ok {
+		if loc, err := time.LoadLocation(iana); err == nil {
+			logrus.Debugf("[ics] mapped Windows timezone %q -> %q", tzid, iana)
+			return loc
+		}
+	}
+
+	logrus.Warnf("[ics] unknown timezone %q, falling back to UTC", tzid)
+	return time.UTC
+}

--- a/internal/integrations/ics_test.go
+++ b/internal/integrations/ics_test.go
@@ -1,0 +1,270 @@
+package integrations
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/apognu/gocal"
+)
+
+func parseTestEvents(t *testing.T, data string, start, end time.Time) []gocal.Event {
+	t.Helper()
+	c := gocal.NewParser(bytes.NewReader([]byte(data)))
+	c.Start = &start
+	c.End = &end
+	c.Strict.Mode = gocal.StrictModeFailEvent
+	if err := c.Parse(); err != nil {
+		t.Fatalf("parsing test calendar: %v", err)
+	}
+	return c.Events
+}
+
+func TestSingleEvent(t *testing.T) {
+	start := time.Date(2026, 3, 25, 0, 0, 0, 0, time.UTC)
+	end := start.Add(24 * time.Hour)
+	events := parseTestEvents(t, `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:single-event-1
+SUMMARY:Team Meeting
+DTSTART:20260325T160000Z
+DTEND:20260325T170000Z
+DTSTAMP:20260325T100000Z
+END:VEVENT
+END:VCALENDAR`, start, end)
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	evt := convertEvent(events[0])
+	if evt.ID != "single-event-1" {
+		t.Errorf("expected ID single-event-1, got %s", evt.ID)
+	}
+	if evt.Title != "Team Meeting" {
+		t.Errorf("expected title Team Meeting, got %s", evt.Title)
+	}
+	if evt.StartTimeUtc != "2026-03-25T16:00:00Z" {
+		t.Errorf("unexpected StartTimeUtc: %s", evt.StartTimeUtc)
+	}
+	if evt.EndTimeUtc != "2026-03-25T17:00:00Z" {
+		t.Errorf("unexpected EndTimeUtc: %s", evt.EndTimeUtc)
+	}
+}
+
+func TestEventOutsideWindow(t *testing.T) {
+	start := time.Date(2026, 3, 25, 0, 0, 0, 0, time.UTC)
+	end := start.Add(24 * time.Hour)
+	events := parseTestEvents(t, `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:outside-1
+SUMMARY:Old Event
+DTSTART:20260301T160000Z
+DTEND:20260301T170000Z
+DTSTAMP:20260301T100000Z
+END:VEVENT
+END:VCALENDAR`, start, end)
+
+	if len(events) != 0 {
+		t.Fatalf("expected 0 events for out-of-window, got %d", len(events))
+	}
+}
+
+func TestWeeklyRecurrence(t *testing.T) {
+	start := time.Date(2026, 3, 23, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 4, 6, 0, 0, 0, 0, time.UTC)
+	events := parseTestEvents(t, `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:weekly-1
+SUMMARY:Weekly Standup
+DTSTART:20260323T090000Z
+DTEND:20260323T093000Z
+RRULE:FREQ=WEEKLY;BYDAY=MO
+DTSTAMP:20260320T100000Z
+END:VEVENT
+END:VCALENDAR`, start, end)
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 occurrences (Mar 23, Mar 30), got %d", len(events))
+	}
+
+	evt0 := convertEvent(events[0])
+	evt1 := convertEvent(events[1])
+
+	if !strings.HasPrefix(evt0.ID, "weekly-1_") {
+		t.Errorf("recurring event ID should have timestamp suffix, got %s", evt0.ID)
+	}
+	if evt0.StartTimeUtc != "2026-03-23T09:00:00Z" {
+		t.Errorf("first occurrence: %s", evt0.StartTimeUtc)
+	}
+	if evt1.StartTimeUtc != "2026-03-30T09:00:00Z" {
+		t.Errorf("second occurrence: %s", evt1.StartTimeUtc)
+	}
+	if evt0.EndTimeUtc != "2026-03-23T09:30:00Z" {
+		t.Errorf("duration not preserved: %s", evt0.EndTimeUtc)
+	}
+}
+
+func TestExdateExclusion(t *testing.T) {
+	start := time.Date(2026, 3, 23, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 3, 28, 0, 0, 0, 0, time.UTC)
+	events := parseTestEvents(t, `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:exdate-1
+SUMMARY:Daily Sync
+DTSTART:20260323T140000Z
+DTEND:20260323T143000Z
+RRULE:FREQ=DAILY;COUNT=5
+EXDATE:20260325T140000Z
+DTSTAMP:20260320T100000Z
+END:VEVENT
+END:VCALENDAR`, start, end)
+
+	if len(events) != 4 {
+		t.Fatalf("expected 4 occurrences (5 minus 1 EXDATE), got %d", len(events))
+	}
+
+	for _, e := range events {
+		evt := convertEvent(e)
+		if evt.StartTimeUtc == "2026-03-25T14:00:00Z" {
+			t.Error("EXDATE March 25 should have been excluded")
+		}
+	}
+}
+
+func TestAllDayEvent(t *testing.T) {
+	start := time.Date(2026, 3, 24, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 3, 26, 0, 0, 0, 0, time.UTC)
+	events := parseTestEvents(t, `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:allday-1
+SUMMARY:Company Holiday
+DTSTART;VALUE=DATE:20260325
+DTEND;VALUE=DATE:20260326
+DTSTAMP:20260320T100000Z
+END:VEVENT
+END:VCALENDAR`, start, end)
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 all-day event, got %d", len(events))
+	}
+
+	evt := convertEvent(events[0])
+	if evt.StartTimeUtc != "2026-03-25T00:00:00Z" {
+		t.Errorf("all-day start: %s", evt.StartTimeUtc)
+	}
+}
+
+func TestTimezone(t *testing.T) {
+	start := time.Date(2026, 3, 25, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 3, 26, 0, 0, 0, 0, time.UTC)
+	events := parseTestEvents(t, `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:tz-1
+SUMMARY:Denver Meeting
+DTSTART;TZID=America/Denver:20260325T103000
+DTEND;TZID=America/Denver:20260325T110000
+DTSTAMP:20260320T100000Z
+END:VEVENT
+END:VCALENDAR`, start, end)
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	evt := convertEvent(events[0])
+	if evt.StartTimeUtc != "2026-03-25T16:30:00Z" {
+		t.Errorf("expected UTC conversion 16:30, got %s", evt.StartTimeUtc)
+	}
+	if evt.StartTime != "2026-03-25T10:30:00-06:00" {
+		t.Errorf("expected local time with offset, got %s", evt.StartTime)
+	}
+}
+
+func TestOrganizerAndAttendees(t *testing.T) {
+	start := time.Date(2026, 3, 25, 0, 0, 0, 0, time.UTC)
+	end := start.Add(24 * time.Hour)
+	events := parseTestEvents(t, `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:attendee-test
+SUMMARY:Meeting
+DTSTART:20260325T160000Z
+DTEND:20260325T170000Z
+DTSTAMP:20260325T100000Z
+ORGANIZER;CN=Alice Smith:mailto:alice@example.com
+ATTENDEE;CN=Bob Jones;PARTSTAT=ACCEPTED:mailto:bob@example.com
+ATTENDEE;CN=Carol White;PARTSTAT=TENTATIVE:mailto:carol@example.com
+END:VEVENT
+END:VCALENDAR`, start, end)
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	evt := convertEvent(events[0])
+	if evt.Organizer == nil {
+		t.Fatal("expected organizer")
+	}
+	if evt.Organizer.Name != "Alice Smith" {
+		t.Errorf("organizer name: %s", evt.Organizer.Name)
+	}
+	if evt.Organizer.Email != "alice@example.com" {
+		t.Errorf("organizer email: %s", evt.Organizer.Email)
+	}
+	if len(evt.Attendees) != 2 {
+		t.Fatalf("expected 2 attendees, got %d", len(evt.Attendees))
+	}
+	if evt.Attendees[0].Name != "Bob Jones" {
+		t.Errorf("attendee 0 name: %s", evt.Attendees[0].Name)
+	}
+}
+
+func TestMalformedEventSkipped(t *testing.T) {
+	start := time.Date(2026, 3, 25, 0, 0, 0, 0, time.UTC)
+	end := start.Add(24 * time.Hour)
+	events := parseTestEvents(t, `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:good-event
+SUMMARY:Good Event
+DTSTART:20260325T160000Z
+DTEND:20260325T170000Z
+DTSTAMP:20260325T100000Z
+END:VEVENT
+BEGIN:VEVENT
+UID:bad-event
+SUMMARY:Bad Event
+DTSTART;TZID=America/Denver:20260325T103000
+DTEND;TZID=America/Denver:20260325T110000
+DTSTAMP:20260320T100000Z
+X-APPLE-STRUCTURED-LOCATION;VALUE=URI;X-TITLE=123 Main St.
+Bad Unfolded Line
+Another Bad Line:geo:35.0,-95.0
+END:VEVENT
+BEGIN:VEVENT
+UID:good-event-2
+SUMMARY:Also Good
+DTSTART:20260325T180000Z
+DTEND:20260325T190000Z
+DTSTAMP:20260325T100000Z
+END:VEVENT
+END:VCALENDAR`, start, end)
+
+	if len(events) < 1 {
+		t.Fatalf("expected at least 1 good event, got %d", len(events))
+	}
+
+	var titles []string
+	for _, e := range events {
+		titles = append(titles, e.Summary)
+	}
+	found := false
+	for _, title := range titles {
+		if title == "Good Event" || title == "Also Good" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected good events to survive, got titles: %v", titles)
+	}
+}

--- a/internal/integrations/integrations.go
+++ b/internal/integrations/integrations.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/ddvk/rmfakecloud/internal/messages"
 	"github.com/ddvk/rmfakecloud/internal/storage"
@@ -21,6 +22,7 @@ const (
 	DropboxProvider = "dropbox"
 	GoogleProvider  = "google"
 	LocalfsProvider = "localfs"
+	IcsProvider     = "ics"
 )
 
 type IntegrationProvider interface{}
@@ -38,6 +40,12 @@ type StorageIntegrationProvider interface {
 type MessagingIntegrationProvider interface {
 	IntegrationProvider
 	SendMessage(data messages.IntegrationMessageData, img image.Image) (string, error)
+}
+
+// CalendarIntegrationProvider abstracts calendar integrations
+type CalendarIntegrationProvider interface {
+	IntegrationProvider
+	ListEvents(windowStart, windowEnd time.Time) (*messages.CalendarEventsResponse, error)
 }
 
 // getIntegrationProvider finds the integration provider for the user
@@ -61,9 +69,11 @@ func getIntegrationProvider(storer storage.UserStorer, uid, integrationid string
 			return newLocalFS(intg), nil
 		case WebdavProvider:
 			return newWebDav(intg), nil
+		case IcsProvider:
+			return newICS(intg), nil
 		}
 	}
-	return nil, fmt.Errorf("integration not found or no implmentation (only webdav) %s", integrationid)
+	return nil, fmt.Errorf("integration not found or no implementation %s", integrationid)
 
 }
 
@@ -95,6 +105,20 @@ func GetMessagingIntegrationProvider(storer storage.UserStorer, uid, integration
 	return sip, nil
 }
 
+func GetCalendarIntegrationProvider(storer storage.UserStorer, uid, integrationid string) (CalendarIntegrationProvider, error) {
+	provider, err := getIntegrationProvider(storer, uid, integrationid)
+	if err != nil {
+		return nil, err
+	}
+
+	cip, ok := provider.(CalendarIntegrationProvider)
+	if !ok {
+		return nil, fmt.Errorf("provider %q is not a calendar provider", integrationid)
+	}
+
+	return cip, nil
+}
+
 // fix the name
 func fixProviderName(n string) string {
 	switch n {
@@ -110,6 +134,8 @@ func fixProviderName(n string) string {
 		fallthrough
 	case WebdavProvider:
 		return "GoogleDrive"
+	case IcsProvider:
+		return "IcsCalendar"
 	default:
 		return n
 	}
@@ -127,6 +153,8 @@ func ProviderType(n string) string {
 		fallthrough
 	case WebdavProvider:
 		return "Storage"
+	case IcsProvider:
+		return "Calendar"
 	default:
 		return n
 	}

--- a/internal/messages/calendar.go
+++ b/internal/messages/calendar.go
@@ -1,0 +1,24 @@
+package messages
+
+type CalendarEventsResponse struct {
+	RetrievedAtUtc string          `json:"retrievedAtUtc"`
+	Events         []CalendarEvent `json:"events"`
+}
+
+type CalendarEvent struct {
+	ID                  string           `json:"id"`
+	Title               string           `json:"title"`
+	StartTimeUtc        string           `json:"startTimeUtc"`
+	EndTimeUtc          string           `json:"endTimeUtc"`
+	LastModifiedTimeUtc string           `json:"lastModifiedTimeUtc"`
+	StartTime           string           `json:"startTime"`
+	EndTime             string           `json:"endTime"`
+	ResponseStatus      string           `json:"responseStatus"`
+	Organizer           *CalendarPerson  `json:"organizer,omitempty"`
+	Attendees           []CalendarPerson `json:"attendees,omitempty"`
+}
+
+type CalendarPerson struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}

--- a/ui/src/pages/Integrations/IntegrationModal.jsx
+++ b/ui/src/pages/Integrations/IntegrationModal.jsx
@@ -98,6 +98,7 @@ export default function IntegrationModal(params) {
               <option value="ftp">FTP</option>
               <option value="dropbox">Dropbox</option>
               <option value="webhook">Messaging webhook</option>
+              <option value="ics">ICS Calendar</option>
             </Form.Control>
 
             <Form.Label>Name</Form.Label>
@@ -150,6 +151,24 @@ export default function IntegrationModal(params) {
                 onChange={({ target }) => setIntegrationForm({ ...integrationForm, [target.name]: target.checked })}
                 label="Use actives transfers"
               />
+            )}
+
+            {integrationForm.provider === "ics" && (
+              <>
+                <Form.Label>ICS URL</Form.Label>
+                <Form.Control
+                  placeholder="https://example.com/calendar.ics"
+                  value={integrationForm.address}
+                  name="address"
+                  onChange={handleChange}
+                />
+                <Form.Check
+                  name="insecure"
+                  checked={integrationForm.insecure}
+                  onChange={({ target }) => setIntegrationForm({ ...integrationForm, [target.name]: target.checked })}
+                  label="Ignore TLS certificate errors"
+                />
+              </>
             )}
 
             {integrationForm.provider === "localfs" && (

--- a/ui/src/pages/Integrations/NewIntegrationModal.jsx
+++ b/ui/src/pages/Integrations/NewIntegrationModal.jsx
@@ -85,7 +85,26 @@ export default function IntegrationProfileModal(params) {
             <option value="webdav">WebDAV</option>
             <option value="dropbox">Dropbox</option>
             <option value="webhook">Messaging webhook</option>
+            <option value="ics">ICS Calendar</option>
           </Form.Select>
+
+          {integrationForm.provider === "ics" && (
+            <>
+              <Form.Label>ICS URL</Form.Label>
+              <Form.Control
+                placeholder="https://example.com/calendar.ics"
+                value={integrationForm.address}
+                name="address"
+                onChange={handleChange}
+              />
+              <Form.Check
+                name="insecure"
+                checked={integrationForm.insecure}
+                onChange={({ target }) => setIntegrationForm({ ...integrationForm, [target.name]: target.checked })}
+                label="Ignore TLS certificate errors"
+              />
+            </>
+          )}
 
           {(integrationForm.provider === "webdav" || integrationForm.provider === "ftp") && (
             <>


### PR DESCRIPTION
Adds support for the calendar integration added in 3.27.

- ICS URL calendar integration
- xochitl user-agent check for >=3.27 to avoid issue where lower rM OSes incorrectly display cal integrations as storage integrations
- Filtering to events happening next 24 hrs to send to tablet, rM OS seems to display even less time
- 5 min cache on events

Draft for now as 3.27 is still in beta, will verify functionality on release version and mark ready for review.