### PR TITLE
feat: env for custom myscript host

### DIFF
--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -24,6 +24,7 @@ Then you'll obtains an application key and its corresponding HMAC to give to rmf
 | `RMAPI_HWR_APPLICATIONKEY` | Application key obtained from myscript |
 | `RMAPI_HWR_HMAC`           | HMAC obtained from myscript |
 | `RMAPI_HWR_LANG_OVERRIDE`  | Optional: Use this if you want your handwriting to be recognized as a different language. This variable accepts a locale code (e.g., zh_CN). Refer to [this page](https://app-support.myscript.com/support/solutions/articles/16000086001-supported-languages) for supported languages.|
+| `RMAPI_HWR_HOST`           | Optional: Custom myScript host URL (default: `https://cloud.myscript.com`). Supports http/https and custom ports. |
 
 ## Email settings
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,6 +72,7 @@ const (
 	envHwrHmac = "RMAPI_HWR_HMAC"
 	// envHwrLangOverride override the language specified in myScript requests
 	envHwrLangOverride = "RMAPI_HWR_LANG_OVERRIDE"
+	envHwrHost         = "RMAPI_HWR_HOST"
 	// EnvLogFile log file to use
 	EnvLogFile     = "RM_LOGFILE"
 	envHTTPSCookie = "RM_HTTPS_COOKIE"
@@ -99,6 +100,7 @@ type Config struct {
 	HWRApplicationKey string
 	HWRHmac           string
 	HWRLangOverride   string
+	HWRHost           string
 	HTTPSCookie       bool
 	TrustProxy        bool
 	MQTTPort          string
@@ -270,6 +272,7 @@ func FromEnv() *Config {
 		HWRApplicationKey: os.Getenv(envHwrApplicationKey),
 		HWRHmac:           os.Getenv(envHwrHmac),
 		HWRLangOverride:   os.Getenv(envHwrLangOverride),
+		HWRHost:           os.Getenv(envHwrHost),
 		HTTPSCookie:       httpsCookie,
 		TrustProxy:        trustProxy,
 		MQTTPort:          mqttPort,
@@ -320,6 +323,7 @@ myScript hwr (needs a developer account):
 	%s
 	%s
 	%s      override the language specified in myScript requests
+	%s      custom myScript host URL (default: https://cloud.myscript.com)
 `,
 		envJWTSecretKey,
 		EnvStorageURL,
@@ -351,5 +355,6 @@ myScript hwr (needs a developer account):
 		envHwrApplicationKey,
 		envHwrHmac,
 		envHwrLangOverride,
+		envHwrHost,
 	)
 }

--- a/internal/hwr/client.go
+++ b/internal/hwr/client.go
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	url = "https://cloud.myscript.com/api/v4.0/iink/batch"
+	defaultHost = "https://cloud.myscript.com"
+	apiPath     = "/api/v4.0/iink/batch"
 
 	// JIIX jiix type
 	JIIX = "application/vnd.myscript.jiix"
@@ -67,7 +68,12 @@ func (hwr *HWRClient) SendRequest(data []byte) (body []byte, err error) {
 
 	client := http.Client{}
 
-	req, err := http.NewRequest("POST", url, bytes.NewReader(data))
+	host := defaultHost
+	if hwr.Cfg.HWRHost != "" {
+		host = hwr.Cfg.HWRHost
+	}
+
+	req, err := http.NewRequest("POST", host+apiPath, bytes.NewReader(data))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This makes the HWR host configurable with the goal being community-developed iink-compatible API services could be pointed to instead of MyScript.