### PR TITLE
Update external access installation instructions

### DIFF
--- a/docs/install/external-access.md
+++ b/docs/install/external-access.md
@@ -115,8 +115,8 @@ Install `rmfakecloud-proxy` as the [installation instructions](../remarkable/set
 
 When asked for the cloud url, enter your public address. In this case, `https://rmfakecloud.example.com`.
 
-In path to client certificate file, enter `client.crt`.
+In path to client certificate file, enter `client.crt`. Do not enter as a path, only use the name of the file you have placed in the `/home/root/rmfakecloud` folder.
 
-In path to client key file, enter `client.key`.
+In path to client key file, enter `client.key`. Again, only enter as a filename, not the path.
 
 You should now be able to sync your reMarkable from outside your local network.

--- a/docs/install/external-access.md
+++ b/docs/install/external-access.md
@@ -119,4 +119,4 @@ In path to client certificate file, enter `client.crt`. Do not enter as a path, 
 
 In path to client key file, enter `client.key`. Again, only enter as a filename, not the path.
 
-You should now be able to sync your reMarkable from outside your local network.
+You should now be able to sync your reMarkable from outside your local network. Pairing does not work using mTLS authentication, and you will run into a cloudflare block screen. Make sure to pair beforehand, or disable the security rule temporarily for pairing.


### PR DESCRIPTION
Clarify instructions for client certificate and key file paths. I was way to long stuck, because I entered rmfakecloud/client.crt as a path. Just using a filename as argument and expecting a fixed location of the file is very unintuitive and should be documented.

Also pairing does not seem to use the proxy and therefore ignores the certificates. 